### PR TITLE
Update to fr.yml

### DIFF
--- a/locale/fr.yml
+++ b/locale/fr.yml
@@ -18,7 +18,7 @@ flagrow-upload:
             preferences:
                 title: Préférences générales
                 max_file_size: Taille maximale du fichier (en kilobytes)
-                mime_types: Déterminer les extensions que vous souhaitez autoriser dans votre application en utilisant une expression régulière
+                mime_types: Déterminez les extensions à autoriser en utilisant une expression régulière
             resize:
                 title: Redimensionnement des images
                 toggle: Redimensionner les images
@@ -47,7 +47,7 @@ flagrow-upload:
             description: >
                 Paramétrer les services et préférences de téléchargement.
             mime_types: >
-                Vous pouvez configurer la correspondance entre le type de donnée et le stockage. Chaque type mime représenté par une expression régulière sera gérée
+                Configurez la correspondance entre le type de données et le stockage. Chaque type mime représenté par une expression régulière sera géré
                 par le service de stockage correspondant.
             upload_method: >
                 Vous pouvez sélectionner la méthode que vous souhaitez utiliser pour joindre vos fichiers. Lorsque vous en sélectionner une, the

--- a/locale/fr.yml
+++ b/locale/fr.yml
@@ -18,7 +18,7 @@ flagrow-upload:
             preferences:
                 title: Préférences générales
                 max_file_size: Taille maximale du fichier (en kilobytes)
-                mime_types_allowed: Déterminer les extensions que vous souhaitez autoriser dans votre application en utilisant une expression régulière
+                mime_types: Déterminer les extensions que vous souhaitez autoriser dans votre application en utilisant une expression régulière
             resize:
                 title: Redimensionnement des images
                 toggle: Redimensionner les images
@@ -46,6 +46,9 @@ flagrow-upload:
         help_texts:
             description: >
                 Paramétrer les services et préférences de téléchargement.
+            mime_types: >
+                Vous pouvez configurer la correspondance entre le type de donnée et le stockage. Chaque type mime représenté par une expression régulière sera gérée
+                par le service de stockage correspondant.
             upload_method: >
                 Vous pouvez sélectionner la méthode que vous souhaitez utiliser pour joindre vos fichiers. Lorsque vous en sélectionner une, the
                 relative setting card is going to be displayed.


### PR DESCRIPTION
- changed key in admin > labels > preferences, from mime_types_allowed to mime_types, to match structure of 0.4.3 en.yml. Translation was fine, so no change applied for it.

- added mime_types key in admin> help_texts with translation, to match structure of 0.4.3 en.yml