### PR TITLE
bugfix

### DIFF
--- a/src/Commands/DownloadHandler.php
+++ b/src/Commands/DownloadHandler.php
@@ -111,7 +111,7 @@ class DownloadHandler
      */
     public static function prependDownloader(Downloader $downloader)
     {
-        Arr::prepend(static::$downloader, $downloader);
+        static::$downloader = Arr::prepend(static::$downloader, $downloader);
     }
 
     /**


### PR DESCRIPTION
 Arr::prepend does not mutate it's argument, it returns new array.