### PR TITLE
Use S3 Static website hosting instead

### DIFF
--- a/src/Adapters/AwsS3.php
+++ b/src/Adapters/AwsS3.php
@@ -28,12 +28,11 @@ class AwsS3 extends Flysystem implements UploadAdapter
         $bucket = $this->adapter->getBucket();
 
         $baseUrl = in_array($region, [null, 'us-east-1']) ?
-            'https://s3.amazonaws.com/' :
-            sprintf('https://s3-%s.amazonaws.com/', $region);
+            sprintf('http://%s.s3-website-us-east-1.amazonaws.com/', $bucket) :
+            sprintf('http://%s.s3-website-%s.amazonaws.com/', $bucket, $region);
 
         $file->url = sprintf(
-            $baseUrl . '%s/%s',
-            $bucket,
+            $baseUrl . '%s',
             Arr::get($this->meta, 'path', $file->path)
         );
     }


### PR DESCRIPTION
As best practice on AWS, you should use the static website hosting feature instead of making your bucket become public. With the static website hosting feature, you could also utilise its redirection feature to utilise CDN like AWS Cloudfront to serve public traffic to your S3 bucket. For more information, please read: https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html