### PR TITLE
'csrf_token' should be '_token'

### DIFF
--- a/src/Api/Controllers/DownloadController.php
+++ b/src/Api/Controllers/DownloadController.php
@@ -54,7 +54,7 @@ class DownloadController implements RequestHandlerInterface
 
         $session = $request->getAttribute('session');
 
-        if ($this->settings->get('disableHotlinkProtection') != 1 && $csrf !== $session->get('csrf_token')) {
+        if ($this->settings->get('disableHotlinkProtection') != 1 && $csrf !== $session->get('_token')) {
             throw new ModelNotFoundException();
         }
 


### PR DESCRIPTION
I found that ```csrf_token``` does not exist in the session. And the key is called ```_token``` in ```vendor/illuminate/session/Store.php```. See the snippet below:

```
    /**
     * Get the CSRF token value.
     *
     * @return string
     */
    public function token()
    {
        return $this->get('_token');
    }
    /**
     * Regenerate the CSRF token value.
     *
     * @return void
     */
    public function regenerateToken()
    {
        $this->put('_token', Str::random(40));
    }
```