### PR TITLE
fix: use TextEditorButton component so that tooltip is showing.

### DIFF
--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -1,6 +1,6 @@
 import app from 'flarum/forum/app';
 import Component from 'flarum/common/Component';
-import Button from 'flarum/common/components/Button';
+import TextEditorButton from 'flarum/common/components/TextEditorButton';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import classList from 'flarum/common/utils/classList';
 
@@ -25,7 +25,7 @@ export default class UploadButton extends Component {
       : app.translator.trans('fof-upload.forum.buttons.upload');
 
     return (
-      <Button
+      <TextEditorButton
         className={classList([
           'Button',
           'hasIcon',
@@ -37,13 +37,14 @@ export default class UploadButton extends Component {
         icon={!this.attrs.uploader.uploading && 'fas fa-file-upload'}
         onclick={this.uploadButtonClicked.bind(this)}
         disabled={this.attrs.disabled}
+        title={buttonText}
       >
         {this.attrs.uploader.uploading && <LoadingIndicator size="small" display="inline" className="Button-icon" />}
         {(this.isMediaUploadButton || this.attrs.uploader.uploading) && <span className="Button-label">{buttonText}</span>}
         <form>
           <input type="file" multiple={true} onchange={this.process.bind(this)} />
         </form>
-      </Button>
+      </TextEditorButton>
     );
   }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Replace the Button component with TextEditorButton so that the tooltip shows up on the upload file button as it does on all the other Text Editor toolbar buttons.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="991" alt="image" src="https://github.com/user-attachments/assets/bac99051-d63e-43d8-858a-191b7d6bd4f9" />

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
