### PR TITLE
Sync wrapping behavior with references

### DIFF
--- a/js/src/forum/addUploadButton.js
+++ b/js/src/forum/addUploadButton.js
@@ -43,7 +43,11 @@ export default function () {
     this.uploader.on('success', ({ file, addBBcode }) => {
       if (!addBBcode) return;
 
-      this.attrs.composer.editor.insertAtCursor(file.bbcode() + '\n', false);
+      const cursorPosition = this.attrs.composer.editor.getSelectionRange()[0];
+      const preceding = this.attrs.composer.fields.content().slice(0, cursorPosition);
+      const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
+
+      this.attrs.composer.editor.insertAtCursor(Array(precedingNewlines).join('\n') + file.bbcode() + '\n', false);
 
       // We wrap this in a typeof check to prevent it running when a user
       // is creating a new discussion. There's nothing to preview in a new

--- a/js/src/forum/components/FileManagerModal.js
+++ b/js/src/forum/components/FileManagerModal.js
@@ -233,7 +233,11 @@ export default class FileManagerModal extends Modal {
     this.selectedFiles.map((fileId) => {
       const file = app.store.getById('files', fileId) || app.store.getById('shared-files', fileId);
 
-      app.composer.editor.insertAtCursor(file.bbcode() + '\n', false);
+      const cursorPosition = app.composer.editor.getSelectionRange()[0];
+      const preceding = app.composer.fields.content().slice(0, cursorPosition);
+      const precedingNewlines = preceding.length == 0 ? 0 : 3 - preceding.match(/(\n{0,2})$/)[0].length;
+      
+      app.composer.editor.insertAtCursor(Array(precedingNewlines).join('\n') + file.bbcode() + '\n', false);
     });
   }
 

--- a/src/Formatter/TextPreview/FormatTextPreview.php
+++ b/src/Formatter/TextPreview/FormatTextPreview.php
@@ -47,7 +47,7 @@ class FormatTextPreview
                 if ($response->getStatusCode() === 200) {
                     $file_contents = $response->getBody()->getContents();
 
-                    $lines = preg_split('/\R/', $file_contents);
+                    $lines = preg_split('/\R/u', $file_contents);
                     $lines = array_filter($lines, 'trim');
 
                     if (count($lines) <= 5) {


### PR DESCRIPTION
	modified:   js/src/forum/components/FileManagerModal.js

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

This PR transplanted the wrapping mechanism from references, to make insertion more friendly, especially with rich text editor.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
