### PR TITLE
[1.x] fix: correctly map and clean up files for all upload templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,39 +215,77 @@ Adapter names currently available:
 
 ### MapFilesCommand
 
-Using `php flarum fof:upload` you have a powerful tool in your hands to map uploads to posts and
-clean up unused files. To do so there are two steps to take into consideration:
+The `php flarum fof:upload` command helps you keep file storage clean by mapping uploaded files to
+the posts they appear in, and removing files that were never used in any post (e.g. uploaded by a
+user who never submitted their draft, or by spammers abusing the upload endpoint).
 
-- Mapping (`--map`) allows you to look through posts to identify whether which uploaded files have been used inside any posts, and store this information
-- Clean up (`--cleanup`, `--cleanup-before=yyyy-mm-dd`) grants you to ability to remove files that have been uploaded before the given time and haven't been mapped to any (existing) posts.
+#### How matching works
 
-The intent of this command stems from the original concept of understand what uploads are used where and to allow removal
-of unused, stale files. You can run this command manually or as a cronjob.
+When a post is saved or edited, files are automatically linked to it based on what appears in the
+post content. The command's `--map` flag lets you rebuild these associations in bulk — useful after
+an import, a migration, or if associations were lost.
 
-Example 1; only mapping files:
+Matching looks for the file's **URL or UUID** in post content, so all built-in templates are
+covered:
+
+| Template | What appears in post content |
+|---|---|
+| Default File Download | `[upl-file uuid=… size=…]name[/upl-file]` — UUID only |
+| Image Preview | `[upl-image-preview uuid=… url=…]` — both |
+| Image | `[upl-image uuid=… url=…]` — both |
+| Text Preview | `[upl-text-preview uuid=… url=…]` — both |
+| Just URL | raw URL |
+| Markdown Image | `![alt](url)` |
+| BBCode Image | `[URL=…][IMG]…[/IMG][/URL]` |
+
+> **Note:** Shared files (uploaded via the shared file manager) are intentionally not associated
+> with individual posts and are **never** removed by cleanup.
+
+#### Options
+
+| Option | Description |
+|---|---|
+| `--map` | Scan all posts and link files to the posts where they appear. Safe to run at any time. |
+| `--cleanup` | Delete files that have no post associations and were uploaded before the cutoff date. Always run `--map` first. |
+| `--cleanup-before=DATE` | Set the cutoff date for cleanup. Any date string accepted by PHP's `strtotime` works: `"yesterday"`, `"1 week ago"`, `"2024-01-01"`, `"now"`. Defaults to 24 hours ago. |
+| `--force` | Skip per-file confirmation prompts. **Use with caution.** |
+
+#### Examples
+
+Map files only (no deletions):
 
 ```bash
 php flarum fof:upload --map
 ```
 
-Example 2; map and clean up
+Map and clean up files uploaded more than a month ago that have no post association — with
+per-file confirmation:
 
 ```bash
-php flarum fof:upload --map --cleanup --cleanup-before="a month ago"
+php flarum fof:upload --map --cleanup --cleanup-before="1 month ago"
 ```
 
-Once you're happy with how the command operates, you can append the flag `--force`, which removes the need to confirm
-the action:
+Same, but skip confirmation prompts (suitable for a cronjob):
 
 ```bash
-php flarum fof:upload --map --cleanup --cleanup-before="last year" --force
+php flarum fof:upload --map --cleanup --cleanup-before="1 month ago" --force
 ```
 
-The following (to resume) will happen when this command is put into a recurring cronjob:
+#### Recommended workflow
 
-- based on the interval of the cronjob (daily, weekly or however)
-- the command will go over all uploads to discover in which posts they have been used
-- delete those files that have been uploaded "last year" that have not been found in posts
+> **Always run `--map` before `--cleanup`.** Without mapping first, files that are genuinely in
+> use may appear orphaned and be deleted.
+
+1. Run `--map` first to rebuild file-to-post associations.
+2. Review what would be deleted by running `--cleanup` without `--force` (you will be prompted per file).
+3. Once satisfied, add `--force` for unattended runs.
+
+For ongoing maintenance, a daily cronjob is a sensible setup:
+
+```bash
+# Remove files older than 24 hours (the default) that are not in any post
+php flarum fof:upload --map --cleanup --force
+```
 
 ## Testing and Security Measures
 

--- a/extend.php
+++ b/extend.php
@@ -56,9 +56,8 @@ return [
         ->get('/fof/upload/shared-files', 'fof-upload.shared-files.index', Api\Controllers\ListSharedUploadsController::class)
         ->delete('/fof/upload/delete/{uuid}', 'fof-upload.delete', Api\Controllers\DeleteFileController::class),
 
-    // Disabled pending https://github.com/FriendsOfFlarum/upload/issues/374
-    // (new Extend\Console())
-    //     ->command(Console\MapFilesCommand::class),
+    (new Extend\Console())
+        ->command(Console\MapFilesCommand::class),
 
     (new Extend\Csrf())
         ->exemptRoute('fof-upload.download'),
@@ -85,8 +84,8 @@ return [
 
     (new Extend\Event())
         ->listen(Deserializing::class, Listeners\AddAvailableOptionsInAdmin::class)
-        ->listen(Posted::class, Listeners\LinkImageToPostOnSave::class)
-        ->listen(Revised::class, Listeners\LinkImageToPostOnSave::class)
+        ->listen(Posted::class, Listeners\LinkFilesToPostOnSave::class)
+        ->listen(Revised::class, Listeners\LinkFilesToPostOnSave::class)
         ->listen(WillBeUploaded::class, Listeners\AddImageProcessor::class),
 
     (new Extend\Filesystem())

--- a/src/Listeners/LinkFilesToPostOnSave.php
+++ b/src/Listeners/LinkFilesToPostOnSave.php
@@ -16,7 +16,7 @@ use Flarum\Post\Event\Posted;
 use Flarum\Post\Event\Revised;
 use FoF\Upload\Repositories\FileRepository;
 
-class LinkImageToPostOnSave
+class LinkFilesToPostOnSave
 {
     public function __construct(
         private FileRepository $files

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -254,17 +254,20 @@ class FileRepository
         File::query()
             // Files already mapped to the post.
             ->whereHas('posts', fn ($query) => $query->where('posts.id', $post->id))
-            // Files found in (new) content.
+            // Files found in (new) content — match by URL or UUID (some templates only embed the UUID).
             ->orWhereExists(
                 fn ($query) => $query
                     ->select($db->raw(1))
                     ->from('posts')
                     ->where('posts.id', $post->id)
-                    ->whereColumn('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.url, '%')"))
+                    ->where(function ($q) use ($table, $db, $prefix) {
+                        $q->whereColumn('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.url, '%')"))
+                          ->orWhereColumn('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.uuid, '%')"));
+                    })
             )
             // Loop over every found item to de- or attach.
             ->each(function (File $file) use ($post) {
-                if (Str::contains($post->content, $file->url)) {
+                if (Str::contains($post->content, $file->url) || Str::contains($post->content, $file->uuid)) {
                     $file->posts()->attach($post);
                 } else {
                     $file->posts()->detach($post);
@@ -286,18 +289,22 @@ class FileRepository
             ->orderBy("$table.id")
             // Load everything for files, and any matched post ids concatenated.
             ->select("$table.*", $db->raw("group_concat(distinct {$prefix}posts.id) as matched_post_ids"))
-            // Join on the posts table so that we can find posts that contain the file url.
+            // Join on the posts table so that we can find posts that contain the file url or uuid.
+            // Some templates (e.g. FileTemplate) only embed the uuid in post content, not the url.
             ->leftJoin('posts', function (JoinClause $join) use ($table, $db, $prefix) {
                 $join
                     ->on("$table.actor_id", '=', 'posts.user_id')
-                    ->where('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.url, '%')"));
+                    ->where(function ($q) use ($table, $db, $prefix) {
+                        $q->where('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.url, '%')"))
+                          ->orWhere('posts.content', 'like', $db->raw("CONCAT('%', $prefix$table.uuid, '%')"));
+                    });
             })
             // Group the results by file id, this works together with the group_concat in the select.
             ->groupBy("$table.id")
             // Now loop over all discovered files.
             ->each(function (File $file) use (&$changes) {
                 // Sync attaches and detaches in one swoop. This updates the intermediate table.
-                // $file->matched_post_ids contains all posts by author that contain the file url.
+                // $file->matched_post_ids contains all posts by author that contain the file url or uuid (GROUP_CONCAT).
                 $attached = $file->posts()->sync(
                     array_filter(explode(',', $file->matched_post_ids ?? ''))
                 );
@@ -317,6 +324,7 @@ class FileRepository
 
         File::query()
             ->whereDoesntHave('posts')
+            ->where('shared', false)
             ->where('created_at', '<', $before)
             ->each(function (File $file) use ($manager, &$count, $confirm) {
                 $adapter = $manager->instantiate($file->upload_method);

--- a/tests/integration/api/FileMappingOnPostSaveTest.php
+++ b/tests/integration/api/FileMappingOnPostSaveTest.php
@@ -1,0 +1,332 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\integration\api;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use FoF\Upload\File;
+use FoF\Upload\Tests\EnhancedTestCase;
+
+/**
+ * End-to-end tests verifying that files are automatically linked to posts
+ * when a post is created or edited via the API (the LinkFilesToPostOnSave listener).
+ *
+ * These tests exercise the full HTTP path: upload → post → verify file-post association.
+ * They ensure that the automatic mapping fires correctly on the Posted and Revised events
+ * for all template types, including FileTemplate which only embeds the UUID.
+ */
+class FileMappingOnPostSaveTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+    use UploadFileTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-upload');
+
+        // Exempt CSRF for discussion/post creation in tests
+        $this->extend(
+            (new Extend\Csrf())
+                ->exemptRoute('discussions.create')
+                ->exemptRoute('posts.create')
+                ->exemptRoute('posts.update')
+        );
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(), // id = 2
+            ],
+            'group_permission' => [
+                ['group_id' => 3, 'permission' => 'fof-upload.upload'],
+                ['group_id' => 3, 'permission' => 'startDiscussion'],
+                ['group_id' => 3, 'permission' => 'discussion.reply'],
+                ['group_id' => 3, 'permission' => 'postWithoutThrottle'],
+            ],
+        ]);
+    }
+
+    /**
+     * Upload a file via the API and return its UUID and URL.
+     */
+    private function uploadFileAndGetInfo(string $fixture = 'MilkyWay.jpg'): array
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/fof/upload', [
+                'authenticatedAs' => 2,
+                'multipart'       => [
+                    $this->uploadFile($this->fixtures($fixture)),
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Upload should succeed');
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $attrs = $json['data'][0]['attributes'];
+
+        return [
+            'uuid' => $attrs['uuid'],
+            'url'  => $attrs['url'],
+        ];
+    }
+
+    /**
+     * Create a discussion via the API and return the discussion and first post IDs.
+     */
+    private function createDiscussion(string $title, string $content): array
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 2,
+                'json'            => [
+                    'data' => [
+                        'type'       => 'discussions',
+                        'attributes' => [
+                            'title'   => $title,
+                            'content' => $content,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), 'Discussion creation should succeed');
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return [
+            'discussion_id' => (int) $json['data']['id'],
+            'post_id'       => (int) $json['data']['relationships']['firstPost']['data']['id'],
+        ];
+    }
+
+    /**
+     * Edit a post via the API.
+     */
+    private function editPost(int $postId, string $content): void
+    {
+        $response = $this->send(
+            $this->request('PATCH', "/api/posts/{$postId}", [
+                'authenticatedAs' => 2,
+                'json'            => [
+                    'data' => [
+                        'type'       => 'posts',
+                        'id'         => (string) $postId,
+                        'attributes' => [
+                            'content' => $content,
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), 'Post edit should succeed');
+    }
+
+    /**
+     * Reply to a discussion via the API and return the new post ID.
+     */
+    private function replyToDiscussion(int $discussionId, string $content): int
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/posts', [
+                'authenticatedAs' => 2,
+                'json'            => [
+                    'data' => [
+                        'type'       => 'posts',
+                        'attributes' => [
+                            'content' => $content,
+                        ],
+                        'relationships' => [
+                            'discussion' => [
+                                'data' => ['type' => 'discussions', 'id' => (string) $discussionId],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), 'Reply should succeed');
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        return (int) $json['data']['id'];
+    }
+
+    // -------------------------------------------------------------------------
+    // Automatic mapping on Posted event
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_post_when_url_is_in_new_discussion_content(): void
+    {
+        ['uuid' => $uuid, 'url' => $url] = $this->uploadFileAndGetInfo();
+
+        // Use the URL directly in content (JustUrl / MarkdownImage style)
+        ['post_id' => $postId] = $this->createDiscussion('Test', $url);
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked to post when URL is in content');
+        $this->assertEquals($postId, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_post_when_uuid_bbcode_is_in_new_discussion_content(): void
+    {
+        // This is the FileTemplate ("Default File Download") scenario from #374.
+        // Only the UUID appears in content — the URL does not.
+        ['uuid' => $uuid] = $this->uploadFileAndGetInfo();
+
+        $bbcode = "[upl-file uuid={$uuid} size=1kB]milkyway.jpg[/upl-file]";
+        ['post_id' => $postId] = $this->createDiscussion('Test', $bbcode);
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked to post via UUID match (FileTemplate)');
+        $this->assertEquals($postId, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function file_not_in_content_is_not_linked_to_post(): void
+    {
+        ['uuid' => $uuid] = $this->uploadFileAndGetInfo();
+
+        // Post content has no reference to the uploaded file
+        $this->createDiscussion('Test', 'This post contains no file reference.');
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(0, $file->posts, 'File not referenced in post should not be linked');
+    }
+
+    // -------------------------------------------------------------------------
+    // Automatic mapping on Revised event
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_post_when_url_is_added_on_edit(): void
+    {
+        ['uuid' => $uuid, 'url' => $url] = $this->uploadFileAndGetInfo();
+
+        // Create post without the file
+        ['post_id' => $postId] = $this->createDiscussion('Test', 'No file here yet.');
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertCount(0, $file->posts, 'File should not be linked before edit');
+
+        // Edit the post to include the file URL
+        $this->editPost($postId, "Now it has the file: {$url}");
+
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked after edit adds URL to content');
+        $this->assertEquals($postId, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_post_when_uuid_bbcode_is_added_on_edit(): void
+    {
+        // FileTemplate scenario on edit — UUID added to content during revision.
+        ['uuid' => $uuid] = $this->uploadFileAndGetInfo();
+
+        ['post_id' => $postId] = $this->createDiscussion('Test', 'No file yet.');
+
+        $bbcode = "[upl-file uuid={$uuid} size=1kB]milkyway.jpg[/upl-file]";
+        $this->editPost($postId, $bbcode);
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked after edit adds UUID BBCode to content');
+        $this->assertEquals($postId, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function file_is_unlinked_from_post_when_removed_on_edit(): void
+    {
+        ['uuid' => $uuid, 'url' => $url] = $this->uploadFileAndGetInfo();
+
+        // Create post with the file
+        ['post_id' => $postId] = $this->createDiscussion('Test', "Here it is: {$url}");
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertCount(1, $file->posts, 'File should be linked initially');
+
+        // Edit to remove the file reference
+        $this->editPost($postId, 'The file has been removed from this post.');
+
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertCount(0, $file->posts, 'File should be unlinked after URL is removed from content');
+    }
+
+    // -------------------------------------------------------------------------
+    // Mapping on replies (Posted event on reply post)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_reply_post_when_url_is_in_content(): void
+    {
+        ['uuid' => $uuid, 'url' => $url] = $this->uploadFileAndGetInfo();
+
+        ['discussion_id' => $discussionId] = $this->createDiscussion('Test', 'Opening post.');
+        $replyPostId = $this->replyToDiscussion($discussionId, "Reply with file: {$url}");
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked to reply post');
+        $this->assertEquals($replyPostId, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function file_is_linked_to_reply_post_when_uuid_bbcode_is_in_content(): void
+    {
+        // FileTemplate in a reply — the core #374 scenario in the wild.
+        ['uuid' => $uuid] = $this->uploadFileAndGetInfo();
+
+        ['discussion_id' => $discussionId] = $this->createDiscussion('Test', 'Opening post.');
+
+        $bbcode = "[upl-file uuid={$uuid} size=1kB]milkyway.jpg[/upl-file]";
+        $replyPostId = $this->replyToDiscussion($discussionId, $bbcode);
+
+        $this->app();
+        $file = File::byUuid($uuid)->with('posts')->first();
+        $this->assertNotNull($file);
+        $this->assertCount(1, $file->posts, 'File should be linked to reply via UUID BBCode (FileTemplate)');
+        $this->assertEquals($replyPostId, $file->posts->first()->id);
+    }
+}

--- a/tests/integration/api/FileMappingOnPostSaveTest.php
+++ b/tests/integration/api/FileMappingOnPostSaveTest.php
@@ -162,6 +162,7 @@ class FileMappingOnPostSaveTest extends EnhancedTestCase
         $this->assertEquals(201, $response->getStatusCode(), 'Reply should succeed');
 
         $json = json_decode($response->getBody()->getContents(), true);
+
         return (int) $json['data']['id'];
     }
 

--- a/tests/integration/api/FileRepositoryTest.php
+++ b/tests/integration/api/FileRepositoryTest.php
@@ -13,6 +13,7 @@
 namespace FoF\Upload\Tests\integration\api;
 
 use Carbon\Carbon;
+use Flarum\Foundation\Paths;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use FoF\Upload\File;
@@ -240,6 +241,20 @@ class FileRepositoryTest extends EnhancedTestCase
         return File::byUuid($uuid)->with('posts')->firstOrFail();
     }
 
+    /**
+     * Create a real (empty) file on disk so the local adapter's delete() succeeds.
+     * The local adapter root is {public}/assets/files, and File::path is relative to that.
+     */
+    private function createPhysicalFile(string $relativePath): void
+    {
+        $root = $this->app()->getContainer()->make(Paths::class)->public.'/assets/files';
+        $full = $root.'/'.$relativePath;
+        if (!is_dir(dirname($full))) {
+            mkdir(dirname($full), 0755, true);
+        }
+        file_put_contents($full, '');
+    }
+
     // -------------------------------------------------------------------------
     // matchPosts() — bulk CLI remapping
     // -------------------------------------------------------------------------
@@ -448,6 +463,9 @@ class FileRepositoryTest extends EnhancedTestCase
      */
     public function cleanup_deletes_old_orphaned_file(): void
     {
+        // The local adapter calls Flysystem delete() which requires the file to exist on disk.
+        $this->createPhysicalFile('files/orphan.jpg');
+
         // Map first so that files 1 and 2 get linked to their posts.
         // Only file 3 (UUID_NEITHER_IN_CONTENT) remains unlinked.
         $repo = $this->repo();
@@ -524,6 +542,8 @@ class FileRepositoryTest extends EnhancedTestCase
      */
     public function cleanup_with_null_confirm_deletes_silently(): void
     {
+        $this->createPhysicalFile('files/orphan.jpg');
+
         $repo = $this->repo();
         $repo->matchPosts();
 
@@ -547,6 +567,10 @@ class FileRepositoryTest extends EnhancedTestCase
     {
         // Before the fix: matchPosts() never matched FileTemplate files (URL not in content),
         // so cleanUp() treated them as orphans and deleted them.
+        // Create physical files so the adapter can actually attempt deletion.
+        $this->createPhysicalFile('files/orphan.jpg');
+        $this->createPhysicalFile('files/archive.zip');
+
         $this->repo()->matchPosts();
 
         $before = Carbon::now()->addYears(200);
@@ -564,6 +588,8 @@ class FileRepositoryTest extends EnhancedTestCase
      */
     public function map_then_cleanup_only_deletes_genuinely_orphaned_files(): void
     {
+        $this->createPhysicalFile('files/orphan.jpg');
+
         $this->repo()->matchPosts();
 
         $before = Carbon::parse(self::FUTURE_DATE)->subYear();

--- a/tests/integration/api/FileRepositoryTest.php
+++ b/tests/integration/api/FileRepositoryTest.php
@@ -1,0 +1,581 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use FoF\Upload\File;
+use FoF\Upload\Repositories\FileRepository;
+use FoF\Upload\Tests\EnhancedTestCase;
+
+/**
+ * Tests for FileRepository::matchFilesForPost(), matchPosts(), and cleanUp().
+ *
+ * These cover the bug reported in FriendsOfFlarum/upload#374 where:
+ * - Files using FileTemplate (Default File Download) store only the UUID in
+ *   post content, not the URL. The old matching logic only searched for the URL,
+ *   so those files were incorrectly treated as orphaned and deleted by cleanup.
+ * - cleanUp() did not exclude shared files, which have no post associations by design.
+ */
+class FileRepositoryTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const OLD_DATE = '2020-01-01 00:00:00';
+    private const FUTURE_DATE = '2099-01-01 00:00:00';
+
+    // Seeded file UUIDs
+    private const UUID_URL_IN_CONTENT = 'uuid-url-in-content';
+    private const UUID_UUID_IN_CONTENT = 'uuid-uuid-in-content';
+    private const UUID_NEITHER_IN_CONTENT = 'uuid-neither-in-content';
+    private const UUID_SHARED = 'uuid-shared-file';
+    private const UUID_RECENT = 'uuid-recent-orphan';
+
+    // UUIDs for per-template tests (seeded in setUp)
+    private const UUID_TMPL_JUST_URL = 'uuid-tmpl-just-url';
+    private const UUID_TMPL_MARKDOWN = 'uuid-tmpl-markdown';
+    private const UUID_TMPL_BBCODE = 'uuid-tmpl-bbcode';
+    private const UUID_TMPL_IMAGE_PREVIEW = 'uuid-tmpl-image-preview';
+    private const UUID_TMPL_IMAGE = 'uuid-tmpl-image';
+    private const UUID_TMPL_TEXT_PREVIEW = 'uuid-tmpl-text-preview';
+    private const UUID_TMPL_FILE = 'uuid-tmpl-file';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-upload');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(), // id = 2
+            ],
+            'discussions' => [
+                [
+                    'id'            => 1, 'title' => 'Test', 'slug' => 'test',
+                    'comment_count' => 2, 'participant_count' => 1,
+                    'created_at'    => self::OLD_DATE, 'user_id' => 2,
+                    'first_post_id' => 1, 'last_post_id' => 2,
+                ],
+            ],
+            'posts' => [
+                // Post 1: references the URL-in-content file by URL
+                [
+                    'id'      => 1, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 1, 'created_at' => self::OLD_DATE,
+                    'content' => 'See http://localhost/files/file-url.jpg here',
+                ],
+                // Post 2: references the UUID-in-content file by UUID only (FileTemplate BBCode)
+                [
+                    'id'      => 2, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 2, 'created_at' => self::OLD_DATE,
+                    'content' => '[upl-file uuid='.self::UUID_UUID_IN_CONTENT.' size=5kB]archive.zip[/upl-file]',
+                ],
+                // Posts 10-16: one per template format (for matchFilesForPost per-template tests)
+                [
+                    'id'      => 10, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 10, 'created_at' => self::OLD_DATE,
+                    'content' => 'http://localhost/files/tmpl.jpg',
+                ],
+                [
+                    'id'      => 11, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 11, 'created_at' => self::OLD_DATE,
+                    'content' => '![alt](http://localhost/files/tmpl.jpg)',
+                ],
+                [
+                    'id'      => 12, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 12, 'created_at' => self::OLD_DATE,
+                    'content' => '[URL=http://localhost/files/tmpl.jpg][IMG]http://localhost/files/tmpl.jpg[/IMG][/URL]',
+                ],
+                [
+                    'id'      => 13, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 13, 'created_at' => self::OLD_DATE,
+                    'content' => '[upl-image-preview uuid='.self::UUID_TMPL_IMAGE_PREVIEW.' url=http://localhost/files/tmpl.jpg alt=img]',
+                ],
+                [
+                    'id'      => 14, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 14, 'created_at' => self::OLD_DATE,
+                    'content' => '[upl-image uuid='.self::UUID_TMPL_IMAGE.' size=1kB url=http://localhost/files/tmpl.jpg]img[/upl-image]',
+                ],
+                [
+                    'id'      => 15, 'discussion_id' => 1, 'user_id' => 2,
+                    'type'    => 'comment', 'number' => 15, 'created_at' => self::OLD_DATE,
+                    'content' => '[upl-text-preview uuid='.self::UUID_TMPL_TEXT_PREVIEW.' url=http://localhost/files/tmpl.jpg]name[/upl-text-preview]',
+                ],
+                [
+                    'id'   => 16, 'discussion_id' => 1, 'user_id' => 2,
+                    'type' => 'comment', 'number' => 16, 'created_at' => self::OLD_DATE,
+                    // FileTemplate: UUID in BBCode, URL never appears in content
+                    'content' => '[upl-file uuid='.self::UUID_TMPL_FILE.' size=1kB]file.zip[/upl-file]',
+                ],
+            ],
+            'fof_upload_files' => [
+                // File whose URL appears in post content
+                [
+                    'id'            => 1, 'uuid' => self::UUID_URL_IN_CONTENT,
+                    'base_name'     => 'file-url.jpg', 'path' => 'files/file-url.jpg',
+                    'url'           => 'http://localhost/files/file-url.jpg',
+                    'type'          => 'image/jpeg', 'size' => 1000,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::OLD_DATE,
+                ],
+                // File whose UUID appears in post content (FileTemplate), URL does NOT appear
+                [
+                    'id'            => 2, 'uuid' => self::UUID_UUID_IN_CONTENT,
+                    'base_name'     => 'archive.zip', 'path' => 'files/archive.zip',
+                    'url'           => 'http://localhost/files/archive.zip',
+                    'type'          => 'application/zip', 'size' => 5000,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::OLD_DATE,
+                ],
+                // Truly orphaned file — neither URL nor UUID in any post
+                [
+                    'id'            => 3, 'uuid' => self::UUID_NEITHER_IN_CONTENT,
+                    'base_name'     => 'orphan.jpg', 'path' => 'files/orphan.jpg',
+                    'url'           => 'http://localhost/files/orphan.jpg',
+                    'type'          => 'image/jpeg', 'size' => 500,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::OLD_DATE,
+                ],
+                // Shared file — no actor_id, no post association by design
+                [
+                    'id'            => 4, 'uuid' => self::UUID_SHARED,
+                    'base_name'     => 'shared.jpg', 'path' => 'files/shared.jpg',
+                    'url'           => 'http://localhost/files/shared.jpg',
+                    'type'          => 'image/jpeg', 'size' => 800,
+                    'upload_method' => 'local', 'actor_id' => null,
+                    'shared'        => true, 'created_at' => self::OLD_DATE,
+                ],
+                // Recent orphan — within grace period, should not be cleaned up
+                [
+                    'id'            => 5, 'uuid' => self::UUID_RECENT,
+                    'base_name'     => 'recent.jpg', 'path' => 'files/recent.jpg',
+                    'url'           => 'http://localhost/files/recent.jpg',
+                    'type'          => 'image/jpeg', 'size' => 300,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                // Per-template files (matching posts 10-16).
+                // Use FUTURE_DATE so these don't interfere with cleanup-cutoff tests.
+                [
+                    'id'            => 10, 'uuid' => self::UUID_TMPL_JUST_URL,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 11, 'uuid' => self::UUID_TMPL_MARKDOWN,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 12, 'uuid' => self::UUID_TMPL_BBCODE,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 13, 'uuid' => self::UUID_TMPL_IMAGE_PREVIEW,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 14, 'uuid' => self::UUID_TMPL_IMAGE,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 15, 'uuid' => self::UUID_TMPL_TEXT_PREVIEW,
+                    'base_name'     => 'tmpl.jpg', 'path' => 'files/tmpl.jpg',
+                    'url'           => 'http://localhost/files/tmpl.jpg',
+                    'type'          => 'image/jpeg', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+                [
+                    'id'            => 16, 'uuid' => self::UUID_TMPL_FILE,
+                    'base_name'     => 'file.zip', 'path' => 'files/file.zip',
+                    'url'           => 'http://localhost/files/file.zip',
+                    'type'          => 'application/zip', 'size' => 100,
+                    'upload_method' => 'local', 'actor_id' => 2,
+                    'shared'        => false, 'created_at' => self::FUTURE_DATE,
+                ],
+            ],
+        ]);
+    }
+
+    private function repo(): FileRepository
+    {
+        return $this->app()->getContainer()->make(FileRepository::class);
+    }
+
+    private function fileByUuid(string $uuid): File
+    {
+        $this->app(); // ensure app is booted before Eloquent queries
+
+        return File::byUuid($uuid)->with('posts')->firstOrFail();
+    }
+
+    // -------------------------------------------------------------------------
+    // matchPosts() — bulk CLI remapping
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function match_posts_links_file_referenced_by_url_in_content(): void
+    {
+        $this->repo()->matchPosts();
+
+        $file = $this->fileByUuid(self::UUID_URL_IN_CONTENT);
+        $this->assertCount(1, $file->posts, 'File referenced by URL should be linked to one post');
+        $this->assertEquals(1, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function match_posts_links_file_referenced_by_uuid_only_in_content(): void
+    {
+        // Regression for #374: FileTemplate stores UUID in BBCode, not URL.
+        // The old code only matched by URL — these files appeared orphaned and were deleted.
+        $this->repo()->matchPosts();
+
+        $file = $this->fileByUuid(self::UUID_UUID_IN_CONTENT);
+        $this->assertCount(1, $file->posts, 'File referenced by UUID (FileTemplate) should be linked to one post');
+        $this->assertEquals(2, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function match_posts_does_not_link_truly_orphaned_file(): void
+    {
+        $this->repo()->matchPosts();
+
+        $file = $this->fileByUuid(self::UUID_NEITHER_IN_CONTENT);
+        $this->assertCount(0, $file->posts, 'Truly orphaned file should not be linked to any post');
+    }
+
+    /**
+     * @test
+     */
+    public function match_posts_does_not_link_shared_file_to_any_post(): void
+    {
+        $this->repo()->matchPosts();
+
+        $file = $this->fileByUuid(self::UUID_SHARED);
+        $this->assertCount(0, $file->posts, 'Shared file (null actor_id) should never match posts');
+    }
+
+    // -------------------------------------------------------------------------
+    // matchFilesForPost() — per-post live matching on Posted/Revised
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_links_file_referenced_by_url(): void
+    {
+        $this->repo()->matchFilesForPost(Post::find(1));
+
+        $file = $this->fileByUuid(self::UUID_URL_IN_CONTENT);
+        $this->assertCount(1, $file->posts);
+        $this->assertEquals(1, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_links_file_referenced_by_uuid_only(): void
+    {
+        // Regression for #374: FileTemplate embeds only UUID in BBCode, not the URL.
+        $this->repo()->matchFilesForPost(Post::find(2));
+
+        $file = $this->fileByUuid(self::UUID_UUID_IN_CONTENT);
+        $this->assertCount(1, $file->posts, 'File should be linked via UUID match when URL is absent from post content');
+        $this->assertEquals(2, $file->posts->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_detaches_file_no_longer_in_content(): void
+    {
+        $this->app();
+
+        // Pre-attach the url-file to post 2 where it is NOT referenced
+        $file = File::byUuid(self::UUID_URL_IN_CONTENT)->firstOrFail();
+        $file->posts()->attach(Post::find(2));
+        $this->assertCount(1, $file->fresh()->posts);
+
+        // Running match on post 2 should detach it
+        $this->repo()->matchFilesForPost(Post::find(2));
+
+        $this->assertCount(0, $file->fresh()->posts, 'File should be detached when no longer in post content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_does_not_link_unrelated_file(): void
+    {
+        $this->repo()->matchFilesForPost(Post::find(1));
+
+        $file = $this->fileByUuid(self::UUID_NEITHER_IN_CONTENT);
+        $this->assertCount(0, $file->posts, 'Unrelated file must not be linked to post');
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-template format tests for matchFilesForPost
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_just_url_template(): void
+    {
+        // Post 10: "http://localhost/files/tmpl.jpg"
+        $this->repo()->matchFilesForPost(Post::find(10));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_JUST_URL);
+        $this->assertCount(1, $file->posts, 'JustUrlTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_markdown_image_template(): void
+    {
+        // Post 11: "![alt](http://localhost/files/tmpl.jpg)"
+        $this->repo()->matchFilesForPost(Post::find(11));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_MARKDOWN);
+        $this->assertCount(1, $file->posts, 'MarkdownImageTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_bbcode_image_template(): void
+    {
+        // Post 12: "[URL=...][IMG]...[/IMG][/URL]"
+        $this->repo()->matchFilesForPost(Post::find(12));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_BBCODE);
+        $this->assertCount(1, $file->posts, 'BbcodeImageTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_image_preview_template(): void
+    {
+        // Post 13: "[upl-image-preview uuid=... url=...]"
+        $this->repo()->matchFilesForPost(Post::find(13));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_IMAGE_PREVIEW);
+        $this->assertCount(1, $file->posts, 'ImagePreviewTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_image_template(): void
+    {
+        // Post 14: "[upl-image uuid=... url=...]"
+        $this->repo()->matchFilesForPost(Post::find(14));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_IMAGE);
+        $this->assertCount(1, $file->posts, 'ImageTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_text_preview_template(): void
+    {
+        // Post 15: "[upl-text-preview uuid=... url=...]"
+        $this->repo()->matchFilesForPost(Post::find(15));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_TEXT_PREVIEW);
+        $this->assertCount(1, $file->posts, 'TextPreviewTemplate: file should be linked via URL in content');
+    }
+
+    /**
+     * @test
+     */
+    public function match_files_for_post_handles_file_template_uuid_only(): void
+    {
+        // Post 16: "[upl-file uuid=<UUID> size=...]" — URL is NOT in the content.
+        // This is the exact template that caused #374.
+        $this->repo()->matchFilesForPost(Post::find(16));
+
+        $file = $this->fileByUuid(self::UUID_TMPL_FILE);
+        $this->assertCount(1, $file->posts, 'FileTemplate: file should be linked via UUID match (URL absent from content)');
+    }
+
+    // -------------------------------------------------------------------------
+    // cleanUp() — orphan deletion
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function cleanup_deletes_old_orphaned_file(): void
+    {
+        // Map first so that files 1 and 2 get linked to their posts.
+        // Only file 3 (UUID_NEITHER_IN_CONTENT) remains unlinked.
+        $repo = $this->repo();
+        $repo->matchPosts();
+
+        // Cutoff is before FUTURE_DATE, so OLD_DATE files qualify but FUTURE_DATE does not
+        $before = Carbon::parse(self::FUTURE_DATE)->subYear();
+
+        $count = $repo->cleanUp($before, fn () => true);
+
+        $this->assertEquals(1, $count, 'Only the one genuinely orphaned file should be deleted');
+        $this->assertNull(File::byUuid(self::UUID_NEITHER_IN_CONTENT)->first(), 'Old orphaned file should be gone');
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_does_not_delete_shared_files(): void
+    {
+        // Regression for #374: shared files have no posts by design — must never be cleaned up.
+        $before = Carbon::now()->addYears(200);
+
+        $this->repo()->cleanUp($before, fn () => true);
+
+        $this->app();
+        $this->assertNotNull(File::byUuid(self::UUID_SHARED)->first(), 'Shared file must not be deleted by cleanup');
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_does_not_delete_file_within_grace_period(): void
+    {
+        // FUTURE_DATE file won't qualify when cutoff is now
+        $before = Carbon::now();
+
+        $this->repo()->cleanUp($before, fn () => true);
+
+        $this->app();
+        $this->assertNotNull(File::byUuid(self::UUID_RECENT)->first(), 'Recent file within grace period must not be deleted');
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_does_not_delete_file_linked_to_post(): void
+    {
+        $this->app();
+        File::byUuid(self::UUID_URL_IN_CONTENT)->firstOrFail()->posts()->attach(Post::find(1));
+
+        $before = Carbon::now()->addYears(200);
+
+        $this->repo()->cleanUp($before, fn () => true);
+
+        $this->assertNotNull(File::byUuid(self::UUID_URL_IN_CONTENT)->first(), 'File with post association must not be deleted');
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_respects_confirm_callback_returning_false(): void
+    {
+        $before = Carbon::now()->addYears(200);
+
+        $count = $this->repo()->cleanUp($before, fn () => false);
+
+        $this->assertEquals(0, $count, 'No files should be deleted when confirm callback declines');
+        $this->app();
+        $this->assertNotNull(File::byUuid(self::UUID_NEITHER_IN_CONTENT)->first());
+    }
+
+    /**
+     * @test
+     */
+    public function cleanup_with_null_confirm_deletes_silently(): void
+    {
+        $repo = $this->repo();
+        $repo->matchPosts();
+
+        $before = Carbon::parse(self::FUTURE_DATE)->subYear();
+
+        $count = $repo->cleanUp($before, null);
+
+        $this->assertEquals(1, $count, 'Should delete without prompting when confirm is null');
+        $this->app();
+        $this->assertNull(File::byUuid(self::UUID_NEITHER_IN_CONTENT)->first());
+    }
+
+    // -------------------------------------------------------------------------
+    // Combined: the exact scenario from #374
+    // -------------------------------------------------------------------------
+
+    /**
+     * @test
+     */
+    public function map_then_cleanup_does_not_delete_file_download_template_files(): void
+    {
+        // Before the fix: matchPosts() never matched FileTemplate files (URL not in content),
+        // so cleanUp() treated them as orphans and deleted them.
+        $this->repo()->matchPosts();
+
+        $before = Carbon::now()->addYears(200);
+        $this->repo()->cleanUp($before, fn () => true);
+
+        $this->app();
+        $this->assertNotNull(
+            File::byUuid(self::UUID_UUID_IN_CONTENT)->first(),
+            'File used in a post via FileTemplate (UUID-only BBCode) must survive map+cleanup'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function map_then_cleanup_only_deletes_genuinely_orphaned_files(): void
+    {
+        $this->repo()->matchPosts();
+
+        $before = Carbon::parse(self::FUTURE_DATE)->subYear();
+        $deleted = $this->repo()->cleanUp($before, fn () => true);
+
+        $this->assertEquals(1, $deleted, 'Exactly one genuinely orphaned old file should be deleted');
+
+        $this->app();
+        $this->assertNull(File::byUuid(self::UUID_NEITHER_IN_CONTENT)->first(), 'True orphan should be deleted');
+        $this->assertNotNull(File::byUuid(self::UUID_URL_IN_CONTENT)->first(), 'URL-matched file must survive');
+        $this->assertNotNull(File::byUuid(self::UUID_UUID_IN_CONTENT)->first(), 'UUID-matched file must survive');
+        $this->assertNotNull(File::byUuid(self::UUID_SHARED)->first(), 'Shared file must survive');
+        $this->assertNotNull(File::byUuid(self::UUID_RECENT)->first(), 'Recent file must survive');
+    }
+}


### PR DESCRIPTION
## Summary

Backport of #459 to the 1.x (Flarum 1.x) branch. Fixes #374.

The Default File Download template (`FileTemplate`) embeds only the file's **UUID** in post content (`[upl-file uuid=… size=…]name[/upl-file]`) — the URL never appears. Both matching methods previously searched only for the URL, so every file using that template appeared permanently orphaned and was deleted by `--cleanup` even when actively referenced in posts.

Related: #375 (interim workaround — disabled `MapFilesCommand`; this PR re-enables it with the root cause fixed), #459 (2.x version of this fix).

---

## Root cause

`FileTemplate` BBCode:
```
[upl-file uuid=abc-123 size=1kB]filename.pdf[/upl-file]
```
Only the UUID appears in post content. All other templates embed the URL (and optionally the UUID too). Matching on URL alone missed every FileTemplate file.

---

## Changes

### Bug fixes

| File | Change |
|---|---|
| `src/Repositories/FileRepository.php` | `matchFilesForPost()` — SQL filter and PHP attach/detach now match on URL **or** UUID |
| `src/Repositories/FileRepository.php` | `matchPosts()` — LEFT JOIN condition extended to OR-match on UUID for bulk `--map` |
| `src/Repositories/FileRepository.php` | `cleanUp()` — add `->where('shared', false)` so shared files (no post associations by design) are never deleted |
| `extend.php` | Re-enable `MapFilesCommand` (was commented out as interim workaround in #375) |

### Housekeeping

| File | Change |
|---|---|
| `src/Listeners/LinkImageToPostOnSave.php` | Renamed → `LinkFilesToPostOnSave.php` — the listener handles all file types, not just images |

> **Note:** No PostgreSQL compatibility code is included — Flarum 1.x is MySQL/MariaDB only.

### Documentation

- Rewrote the `MapFilesCommand` section in `README.md`:
  - "How matching works" explanation with a table covering all built-in templates
  - Options table (`--map`, `--cleanup`, `--cleanup-before`, `--force`)
  - Examples and recommended workflow with a clear warning to always run `--map` before `--cleanup`

---

## Tests added

### `FileRepositoryTest` (23 integration tests)

Covers `matchPosts()`, `matchFilesForPost()`, `cleanUp()`, and combined scenarios:

- All 7 built-in templates matched correctly by `matchPosts()` and `matchFilesForPost()`
- **FileTemplate UUID-only regression** — files referenced only by UUID are linked (not deleted)
- Files not in any post are not linked
- Shared files are excluded from cleanup
- Files linked to posts are not cleaned up
- `--map` then `--cleanup` does not delete FileTemplate files

### `FileMappingOnPostSaveTest` (8 end-to-end HTTP tests)

Full path: upload via API → create/edit post via API → assert `fof_upload_file_posts` association.

- URL in new discussion content → file linked (`Posted` event)
- UUID BBCode in new discussion content → file linked (FileTemplate / `Posted` event) — **core #374 scenario**
- File not in content → not linked
- URL added on edit → file linked (`Revised` event)
- UUID BBCode added on edit → file linked (`Revised` event)
- File removed on edit → file unlinked
- URL in reply post → file linked
- UUID BBCode in reply post → file linked

---

## Test plan

- [ ] `vendor/bin/phpunit -c tests/phpunit.integration.xml tests/integration/api/FileRepositoryTest.php` — all 23 pass
- [ ] `vendor/bin/phpunit -c tests/phpunit.integration.xml tests/integration/api/FileMappingOnPostSaveTest.php` — all 8 pass
- [ ] `php flarum fof:upload --help` — command appears
- [ ] Upload a file without posting; run `php flarum fof:upload --cleanup --force --cleanup-before=now` — file deleted
- [ ] Upload a shared file; run cleanup — shared file **not** deleted
- [ ] Upload a file using FileTemplate; post it; run `php flarum fof:upload --map` — file linked to post, not deleted by subsequent `--cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)