### PR TITLE
[2.x] test: add unit tests for all templates; fix image-preview alt text bug

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -190,6 +190,7 @@ fof-upload:
     text_preview:
       expand: Expand preview
       collapse: Collapse preview
+      download: Download file
       error: |
         Error previewing file. It may have been deleted, or the provided file ID is invalid.
       no_snippet_preview: "<preview will appear here after posting>"

--- a/resources/templates/text-preview.blade.php
+++ b/resources/templates/text-preview.blade.php
@@ -28,6 +28,11 @@ $translator = resolve('translator');
         </div>
     </button>
 
+    <a href="{@url}" target="_blank" rel="noopener noreferrer" class="Button hasIcon FofUpload-TextPreviewDownload">
+        <i aria-hidden="true" class="icon fas fa-download Button-icon"></i>
+        <span class="Button-label">@php echo($translator->trans('fof-upload.forum.text_preview.download')); @endphp</span>
+    </a>
+
     <div class="FofUpload-TextPreviewError">
         <p>
             <i aria-hidden="true" class="icon fas fa-exclamation-circle"></i>
@@ -41,6 +46,7 @@ $translator = resolve('translator');
 
             const previewEl = figure.querySelector('.FofUpload-TextPreviewFull');
             const toggleBtn = figure.querySelector('.FofUpload-TextPreviewToggle');
+            const downloadLink = figure.querySelector('.FofUpload-TextPreviewDownload');
 
             function createCodeHtml(text) {
                 const codeEl = document.createElement('code');
@@ -70,9 +76,11 @@ $translator = resolve('translator');
             const isCrossOrigin = url && forumOrigin.origin !== url.origin;
 
             // Cross-origin files (e.g. CDN) cannot be fetched from the browser —
-            // hide the expand toggle but still show the filename and snippet.
+            // hide the expand toggle and show a download link instead.
             if (isCrossOrigin) {
                 toggleBtn.style.display = 'none';
+            } else {
+                downloadLink.style.display = 'none';
             }
 
             let fileContent = null;

--- a/resources/templates/text-preview.blade.php
+++ b/resources/templates/text-preview.blade.php
@@ -40,19 +40,7 @@ $translator = resolve('translator');
             const figure = document.currentScript.parentElement;
 
             const previewEl = figure.querySelector('.FofUpload-TextPreviewFull');
-            const snippetEl = figure.querySelector('.FofUpload-TextPreviewSnippet');
-            const loadingEl = figure.querySelector('.FofUpload-TextPreviewLoading');
             const toggleBtn = figure.querySelector('.FofUpload-TextPreviewToggle');
-
-            const snippetText = '';
-
-            const testUrl = new URL(location.origin);
-            const url = new URL('{@url}');
-
-            if (testUrl.origin !== url.origin) {
-              // Prevent cross-origin requests
-              handleError(new Error('Attempted to fetch a cross-origin file in text preview.'));
-            }
 
             function createCodeHtml(text) {
                 const codeEl = document.createElement('code');
@@ -70,10 +58,27 @@ $translator = resolve('translator');
                 console.groupEnd();
             }
 
+            const forumOrigin = new URL(location.origin);
+            let url;
+            try {
+                url = new URL('{@url}');
+            } catch (e) {
+                handleError(e);
+                url = null;
+            }
+
+            const isCrossOrigin = url && forumOrigin.origin !== url.origin;
+
+            // Cross-origin files (e.g. CDN) cannot be fetched from the browser —
+            // hide the expand toggle but still show the filename and snippet.
+            if (isCrossOrigin) {
+                toggleBtn.style.display = 'none';
+            }
+
             let fileContent = null;
 
-            // Only allow toggling preview if showing a snippet
-            if ({@has_snippet} && testUrl.origin === url.origin) {
+            // Only wire up the expand toggle if we have a snippet and a same-origin URL.
+            if ({@has_snippet} && url && !isCrossOrigin) {
                 toggleBtn.addEventListener('click', () => {
                     if (fileContent !== null) {
                         const expanded = figure.getAttribute('data-expanded') === 'true';

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -50,10 +50,6 @@ class FormatImagePreview
                     $attributes['url'] = $fileUrl;
                 }
 
-                if (Arr::get($attributes, 'alt') === '{TEXT?}') {
-                    $attributes['alt'] = '';
-                }
-
                 $attributes['title'] = $file->base_name;
             }
 

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -51,6 +51,13 @@ class FormatImagePreview
                 }
 
                 $attributes['title'] = $file->base_name;
+
+                // Set alt to the filename unless the user provided a custom value.
+                // Also handles legacy posts where alt="{TEXT?}" was stored literally.
+                $alt = Arr::get($attributes, 'alt', '');
+                if (empty($alt) || $alt === '{TEXT?}') {
+                    $attributes['alt'] = $file->base_name;
+                }
             }
 
             return $attributes;

--- a/src/Formatter/TextPreview/FormatTextPreview.php
+++ b/src/Formatter/TextPreview/FormatTextPreview.php
@@ -43,6 +43,10 @@ class FormatTextPreview
             $snippet = '';
 
             if ($file) {
+                if ($fileUrl = $this->files->getUrlForFile($file)) {
+                    $attributes['url'] = $fileUrl;
+                }
+
                 $response = $this->downloader->download($file);
                 if ($response->getStatusCode() === 200) {
                     $file_contents = $response->getBody()->getContents();

--- a/src/Templates/ImagePreviewTemplate.php
+++ b/src/Templates/ImagePreviewTemplate.php
@@ -12,6 +12,7 @@
 
 namespace FoF\Upload\Templates;
 
+use FoF\Upload\File;
 use Illuminate\Contracts\View\View;
 
 class ImagePreviewTemplate extends AbstractTextFormatterTemplate
@@ -48,5 +49,10 @@ class ImagePreviewTemplate extends AbstractTextFormatterTemplate
     public function bbcode(): string
     {
         return '[upl-image-preview uuid={IDENTIFIER} url={URL?} alt={TEXT?}]';
+    }
+
+    public function preview(File $file): string
+    {
+        return "[upl-image-preview uuid={$file->uuid} url={$file->url} alt={$file->base_name}]";
     }
 }

--- a/tests/unit/Formatter/FormatImagePreviewTest.php
+++ b/tests/unit/Formatter/FormatImagePreviewTest.php
@@ -23,10 +23,10 @@ class FormatImagePreviewTest extends TestCase
 {
     private function makeFile(string $uuid, string $baseName, string $url): File
     {
-        $file            = new File();
-        $file->uuid      = $uuid;
+        $file = new File();
+        $file->uuid = $uuid;
         $file->base_name = $baseName;
-        $file->url       = $url;
+        $file->url = $url;
 
         return $file;
     }
@@ -64,7 +64,7 @@ class FormatImagePreviewTest extends TestCase
     #[Test]
     public function sets_alt_to_base_name_when_alt_is_absent(): void
     {
-        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
         $formatter = new FormatImagePreview($this->makeRepository($file));
 
         $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
@@ -75,7 +75,7 @@ class FormatImagePreviewTest extends TestCase
     #[Test]
     public function sets_alt_to_base_name_when_alt_is_empty(): void
     {
-        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
         $formatter = new FormatImagePreview($this->makeRepository($file));
 
         $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', ''));
@@ -87,7 +87,7 @@ class FormatImagePreviewTest extends TestCase
     public function sets_alt_to_base_name_when_legacy_placeholder_stored(): void
     {
         // Legacy posts (saved before the fix) have the literal string {TEXT?} stored as the alt value.
-        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
         $formatter = new FormatImagePreview($this->makeRepository($file));
 
         $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', '{TEXT?}'));
@@ -99,7 +99,7 @@ class FormatImagePreviewTest extends TestCase
     #[Test]
     public function preserves_user_supplied_alt_text(): void
     {
-        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
         $formatter = new FormatImagePreview($this->makeRepository($file));
 
         $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', 'My cat on the windowsill'));
@@ -111,7 +111,7 @@ class FormatImagePreviewTest extends TestCase
     #[Test]
     public function sets_title_to_base_name(): void
     {
-        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
         $formatter = new FormatImagePreview($this->makeRepository($file));
 
         $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));

--- a/tests/unit/Formatter/FormatImagePreviewTest.php
+++ b/tests/unit/Formatter/FormatImagePreviewTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\unit\Formatter;
+
+use FoF\Upload\File;
+use FoF\Upload\Formatter\ImagePreview\FormatImagePreview;
+use FoF\Upload\Repositories\FileRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use s9e\TextFormatter\Renderer;
+
+class FormatImagePreviewTest extends TestCase
+{
+    private function makeFile(string $uuid, string $baseName, string $url): File
+    {
+        $file            = new File();
+        $file->uuid      = $uuid;
+        $file->base_name = $baseName;
+        $file->url       = $url;
+
+        return $file;
+    }
+
+    private function makeRepository(File $file): FileRepository
+    {
+        $repo = $this->createMock(FileRepository::class);
+        $repo->method('findByUuid')->willReturn($file);
+        $repo->method('findByUrl')->willReturn($file);
+        $repo->method('getUrlForFile')->willReturn($file->url);
+
+        return $repo;
+    }
+
+    private function makeRenderer(): Renderer
+    {
+        return $this->createStub(Renderer::class);
+    }
+
+    /** Build a minimal XML string as TextFormatter would produce for an image-preview tag. */
+    private function makeXml(string $uuid, string $url, ?string $alt = null): string
+    {
+        $altAttr = $alt !== null ? ' alt="'.htmlspecialchars($alt, ENT_QUOTES).'"' : '';
+
+        return '<r><UPL-IMAGE-PREVIEW uuid="'.$uuid.'" url="'.$url.'"'.$altAttr.'></UPL-IMAGE-PREVIEW></r>';
+    }
+
+    private function invoke(FormatImagePreview $formatter, string $xml): string
+    {
+        return ($formatter)($this->makeRenderer(), null, $xml);
+    }
+
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function sets_alt_to_base_name_when_alt_is_absent(): void
+    {
+        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringContainsString('alt="photo.jpg"', $result);
+    }
+
+    #[Test]
+    public function sets_alt_to_base_name_when_alt_is_empty(): void
+    {
+        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', ''));
+
+        $this->assertStringContainsString('alt="photo.jpg"', $result);
+    }
+
+    #[Test]
+    public function sets_alt_to_base_name_when_legacy_placeholder_stored(): void
+    {
+        // Legacy posts (saved before the fix) have the literal string {TEXT?} stored as the alt value.
+        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', '{TEXT?}'));
+
+        $this->assertStringContainsString('alt="photo.jpg"', $result);
+        $this->assertStringNotContainsString('{TEXT?}', $result);
+    }
+
+    #[Test]
+    public function preserves_user_supplied_alt_text(): void
+    {
+        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg', 'My cat on the windowsill'));
+
+        $this->assertStringContainsString('alt="My cat on the windowsill"', $result);
+        $this->assertStringNotContainsString('alt="photo.jpg"', $result);
+    }
+
+    #[Test]
+    public function sets_title_to_base_name(): void
+    {
+        $file      = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringContainsString('title="photo.jpg"', $result);
+    }
+
+    #[Test]
+    public function updates_url_from_repository(): void
+    {
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://cdn.example.com/photo.jpg');
+
+        $repo = $this->createMock(FileRepository::class);
+        $repo->method('findByUuid')->willReturn($file);
+        $repo->method('getUrlForFile')->willReturn('https://cdn.example.com/photo.jpg');
+
+        $formatter = new FormatImagePreview($repo);
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://origin.example.com/photo.jpg'));
+
+        $this->assertStringContainsString('https://cdn.example.com/photo.jpg', $result);
+    }
+}

--- a/tests/unit/Templates/TemplatesTest.php
+++ b/tests/unit/Templates/TemplatesTest.php
@@ -1,0 +1,591 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\unit\Templates;
+
+use FoF\Upload\Contracts\TextFormatterTemplate;
+use FoF\Upload\File;
+use FoF\Upload\Templates\BbcodeImageTemplate;
+use FoF\Upload\Templates\FileTemplate;
+use FoF\Upload\Templates\ImagePreviewTemplate;
+use FoF\Upload\Templates\ImageTemplate;
+use FoF\Upload\Templates\JustUrlTemplate;
+use FoF\Upload\Templates\MarkdownImageTemplate;
+use FoF\Upload\Templates\TextPreviewTemplate;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[CoversClass(FileTemplate::class)]
+#[CoversClass(ImageTemplate::class)]
+#[CoversClass(ImagePreviewTemplate::class)]
+#[CoversClass(TextPreviewTemplate::class)]
+#[CoversClass(JustUrlTemplate::class)]
+#[CoversClass(MarkdownImageTemplate::class)]
+#[CoversClass(BbcodeImageTemplate::class)]
+class TemplatesTest extends TestCase
+{
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private function makeView(): View
+    {
+        return $this->createStub(View::class);
+    }
+
+    private function makeTranslator(): TranslatorInterface
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        return $translator;
+    }
+
+    private function makeViewFactory(?View $view = null): ViewFactory
+    {
+        $factory = $this->createStub(ViewFactory::class);
+        $factory->method('make')->willReturn($view ?? $this->makeView());
+
+        return $factory;
+    }
+
+    /** Build a File model stub populated with predictable test data. */
+    private function makeFile(): File
+    {
+        $file            = new File();
+        $file->uuid      = 'test-uuid-1234';
+        $file->base_name = 'photo.jpg';
+        $file->url       = 'https://example.com/files/photo.jpg';
+        $file->path      = 'uploads/photo.jpg';
+        $file->size      = 2048;
+        $file->type      = 'image/jpeg';
+
+        return $file;
+    }
+
+    // ---------------------------------------------------------------------------
+    // JustUrlTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function just_url_template_has_correct_tag(): void
+    {
+        $t = new JustUrlTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('just-url', $t->tag());
+    }
+
+    #[Test]
+    public function just_url_template_preview_returns_file_url(): void
+    {
+        $t    = new JustUrlTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertSame($file->url, $t->preview($file));
+    }
+
+    #[Test]
+    public function just_url_template_is_not_a_text_formatter_template(): void
+    {
+        $t = new JustUrlTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertNotInstanceOf(TextFormatterTemplate::class, $t);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MarkdownImageTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function markdown_image_template_has_correct_tag(): void
+    {
+        $t = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('markdown-image', $t->tag());
+    }
+
+    #[Test]
+    public function markdown_image_template_preview_produces_markdown_syntax(): void
+    {
+        $t    = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $preview = $t->preview($file);
+
+        $this->assertSame('![Image description](https://example.com/files/photo.jpg)', $preview);
+    }
+
+    #[Test]
+    public function markdown_image_template_preview_embeds_url(): void
+    {
+        $t    = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->url, $t->preview($file));
+    }
+
+    // ---------------------------------------------------------------------------
+    // BbcodeImageTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function bbcode_image_template_has_correct_tag(): void
+    {
+        $t = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('bbcode-image', $t->tag());
+    }
+
+    #[Test]
+    public function bbcode_image_template_preview_produces_bbcode_syntax(): void
+    {
+        $t    = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $url     = $file->url;
+        $preview = $t->preview($file);
+
+        $this->assertSame("[URL=$url][IMG]{$url}[/IMG][/URL]", $preview);
+    }
+
+    #[Test]
+    public function bbcode_image_template_preview_contains_url_twice(): void
+    {
+        $t    = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        // URL appears in both the [URL=…] wrapper and the [IMG]…[/IMG] inner tag
+        $this->assertSame(2, substr_count($t->preview($file), $file->url));
+    }
+
+    // ---------------------------------------------------------------------------
+    // FileTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function file_template_has_correct_tag(): void
+    {
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('file', $t->tag());
+    }
+
+    #[Test]
+    public function file_template_is_a_text_formatter_template(): void
+    {
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertInstanceOf(TextFormatterTemplate::class, $t);
+    }
+
+    #[Test]
+    public function file_template_bbcode_contains_uuid_and_size_placeholders(): void
+    {
+        $t      = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $bbcode = $t->bbcode();
+
+        $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
+        $this->assertStringContainsString('size={SIMPLETEXT2}', $bbcode);
+        $this->assertStringContainsString('[upl-file', $bbcode);
+        $this->assertStringContainsString('[/upl-file]', $bbcode);
+    }
+
+    #[Test]
+    public function file_template_bbcode_does_not_contain_url_placeholder(): void
+    {
+        // FileTemplate stores only by UUID (no URL in post content)
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertStringNotContainsString('url=', $t->bbcode());
+    }
+
+    #[Test]
+    public function file_template_preview_substitutes_uuid(): void
+    {
+        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->uuid, $t->preview($file));
+    }
+
+    #[Test]
+    public function file_template_preview_substitutes_human_size(): void
+    {
+        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->humanSize, $t->preview($file));
+    }
+
+    #[Test]
+    public function file_template_preview_substitutes_base_name(): void
+    {
+        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->base_name, $t->preview($file));
+    }
+
+    #[Test]
+    public function file_template_preview_contains_no_remaining_placeholders(): void
+    {
+        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $preview = $t->preview($file);
+
+        $this->assertStringNotContainsString('{IDENTIFIER}', $preview);
+        $this->assertStringNotContainsString('{SIMPLETEXT1}', $preview);
+        $this->assertStringNotContainsString('{SIMPLETEXT2}', $preview);
+    }
+
+    #[Test]
+    public function file_template_returns_a_view(): void
+    {
+        $view = $this->makeView();
+        $t    = new FileTemplate($this->makeViewFactory($view), $this->makeTranslator());
+
+        $this->assertSame($view, $t->template());
+    }
+
+    // ---------------------------------------------------------------------------
+    // ImageTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function image_template_has_correct_tag(): void
+    {
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('image', $t->tag());
+    }
+
+    #[Test]
+    public function image_template_is_a_text_formatter_template(): void
+    {
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertInstanceOf(TextFormatterTemplate::class, $t);
+    }
+
+    #[Test]
+    public function image_template_bbcode_contains_uuid_size_and_url_placeholders(): void
+    {
+        $t      = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $bbcode = $t->bbcode();
+
+        $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
+        $this->assertStringContainsString('size={SIMPLETEXT2}', $bbcode);
+        $this->assertStringContainsString('url={URL}', $bbcode);
+        $this->assertStringContainsString('[upl-image', $bbcode);
+        $this->assertStringContainsString('[/upl-image]', $bbcode);
+    }
+
+    #[Test]
+    public function image_template_preview_substitutes_uuid(): void
+    {
+        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->uuid, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_template_preview_substitutes_url(): void
+    {
+        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->url, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_template_preview_substitutes_human_size(): void
+    {
+        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->humanSize, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_template_preview_substitutes_base_name(): void
+    {
+        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->base_name, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_template_preview_contains_no_remaining_placeholders(): void
+    {
+        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $preview = $t->preview($file);
+
+        $this->assertStringNotContainsString('{IDENTIFIER}', $preview);
+        $this->assertStringNotContainsString('{SIMPLETEXT1}', $preview);
+        $this->assertStringNotContainsString('{SIMPLETEXT2}', $preview);
+        $this->assertStringNotContainsString('{URL}', $preview);
+    }
+
+    #[Test]
+    public function image_template_returns_a_view(): void
+    {
+        $view = $this->makeView();
+        $t    = new ImageTemplate($this->makeViewFactory($view), $this->makeTranslator());
+
+        $this->assertSame($view, $t->template());
+    }
+
+    // ---------------------------------------------------------------------------
+    // ImagePreviewTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function image_preview_template_has_correct_tag(): void
+    {
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('image-preview', $t->tag());
+    }
+
+    #[Test]
+    public function image_preview_template_is_a_text_formatter_template(): void
+    {
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertInstanceOf(TextFormatterTemplate::class, $t);
+    }
+
+    #[Test]
+    public function image_preview_template_bbcode_contains_uuid_and_url_placeholders(): void
+    {
+        $t      = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $bbcode = $t->bbcode();
+
+        $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
+        $this->assertStringContainsString('url={URL?}', $bbcode);
+        $this->assertStringContainsString('[upl-image-preview', $bbcode);
+    }
+
+    #[Test]
+    public function image_preview_template_preview_substitutes_uuid(): void
+    {
+        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->uuid, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_preview_template_preview_substitutes_url(): void
+    {
+        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->url, $t->preview($file));
+    }
+
+    #[Test]
+    public function image_preview_template_preview_substitutes_all_placeholders(): void
+    {
+        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $preview = $t->preview($file);
+
+        $this->assertStringNotContainsString('{IDENTIFIER}', $preview);
+        $this->assertStringNotContainsString('{URL?}', $preview);
+        $this->assertStringNotContainsString('{TEXT?}', $preview);
+    }
+
+    #[Test]
+    public function image_preview_template_preview_sets_alt_to_base_name(): void
+    {
+        // Default alt text is the filename. Users who manually edit the BBCode
+        // in their post can override alt= and the formatter will preserve it,
+        // since alt={TEXT?} in bbcode() marks it as an accepted optional attribute.
+        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString("alt={$file->base_name}", $t->preview($file));
+    }
+
+    #[Test]
+    public function image_preview_template_returns_a_view(): void
+    {
+        $view = $this->makeView();
+        $t    = new ImagePreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
+
+        $this->assertSame($view, $t->template());
+    }
+
+    // ---------------------------------------------------------------------------
+    // TextPreviewTemplate
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function text_preview_template_has_correct_tag(): void
+    {
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertSame('text-preview', $t->tag());
+    }
+
+    #[Test]
+    public function text_preview_template_is_a_text_formatter_template(): void
+    {
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+
+        $this->assertInstanceOf(TextFormatterTemplate::class, $t);
+    }
+
+    #[Test]
+    public function text_preview_template_bbcode_contains_uuid_url_and_snippet_placeholders(): void
+    {
+        $t      = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $bbcode = $t->bbcode();
+
+        $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
+        $this->assertStringContainsString('url={URL}', $bbcode);
+        $this->assertStringContainsString('has_snippet=', $bbcode);
+        $this->assertStringContainsString('snippet=', $bbcode);
+        $this->assertStringContainsString('[upl-text-preview', $bbcode);
+        $this->assertStringContainsString('[/upl-text-preview]', $bbcode);
+    }
+
+    #[Test]
+    public function text_preview_template_preview_uses_uuid(): void
+    {
+        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->uuid, $t->preview($file));
+    }
+
+    #[Test]
+    public function text_preview_template_preview_uses_url(): void
+    {
+        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->url, $t->preview($file));
+    }
+
+    #[Test]
+    public function text_preview_template_preview_uses_base_name_as_inner_text(): void
+    {
+        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString($file->base_name, $t->preview($file));
+    }
+
+    #[Test]
+    public function text_preview_template_preview_sets_has_snippet_false(): void
+    {
+        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $this->assertStringContainsString('has_snippet=false', $t->preview($file));
+    }
+
+    #[Test]
+    public function text_preview_template_returns_a_view(): void
+    {
+        $view = $this->makeView();
+        $t    = new TextPreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
+
+        $this->assertSame($view, $t->template());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cross-template: tag uniqueness
+    // ---------------------------------------------------------------------------
+
+    /** @return array<string, array{0: string}> */
+    public static function allTemplateTags(): array
+    {
+        return [
+            'just-url'      => ['just-url'],
+            'markdown-image' => ['markdown-image'],
+            'bbcode-image'  => ['bbcode-image'],
+            'file'          => ['file'],
+            'image'         => ['image'],
+            'image-preview' => ['image-preview'],
+            'text-preview'  => ['text-preview'],
+        ];
+    }
+
+    #[Test]
+    public function all_template_tags_are_unique(): void
+    {
+        $tags = array_map(fn (array $row) => $row[0], self::allTemplateTags());
+
+        $this->assertSame(count($tags), count(array_unique($tags)), 'Duplicate template tag detected');
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cross-template: preview never contains unsubstituted braces
+    // ---------------------------------------------------------------------------
+
+    /** @return array<string, array{0: object}> */
+    public static function allTextFormatterTemplates(): array
+    {
+        // Instantiated with stub dependencies in the data provider via closures;
+        // the actual instances are built inside the test method.
+        return [
+            'file'          => [FileTemplate::class],
+            'image'         => [ImageTemplate::class],
+            'image-preview' => [ImagePreviewTemplate::class],
+            'text-preview'  => [TextPreviewTemplate::class],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('allTextFormatterTemplates')]
+    public function text_formatter_template_preview_substitutes_all_required_placeholders(string $class): void
+    {
+        $t    = new $class($this->makeViewFactory(), $this->makeTranslator());
+        $file = $this->makeFile();
+
+        $preview = $t->preview($file);
+
+        // All data placeholders must be substituted in preview() output.
+        // Optional TextFormatter structural markers like {SIMPLETEXT?} (used for
+        // has_snippet/snippet in text-preview) are left as-is by design.
+        $requiredPlaceholders = [
+            '{IDENTIFIER}',
+            '{SIMPLETEXT1}',
+            '{SIMPLETEXT2}',
+            '{URL}',
+        ];
+
+        foreach ($requiredPlaceholders as $placeholder) {
+            if (str_contains($t->bbcode(), $placeholder)) {
+                $this->assertStringNotContainsString(
+                    $placeholder,
+                    $preview,
+                    "Template $class left required placeholder $placeholder unsubstituted in: $preview"
+                );
+            }
+        }
+    }
+}

--- a/tests/unit/Templates/TemplatesTest.php
+++ b/tests/unit/Templates/TemplatesTest.php
@@ -66,13 +66,13 @@ class TemplatesTest extends TestCase
     /** Build a File model stub populated with predictable test data. */
     private function makeFile(): File
     {
-        $file            = new File();
-        $file->uuid      = 'test-uuid-1234';
+        $file = new File();
+        $file->uuid = 'test-uuid-1234';
         $file->base_name = 'photo.jpg';
-        $file->url       = 'https://example.com/files/photo.jpg';
-        $file->path      = 'uploads/photo.jpg';
-        $file->size      = 2048;
-        $file->type      = 'image/jpeg';
+        $file->url = 'https://example.com/files/photo.jpg';
+        $file->path = 'uploads/photo.jpg';
+        $file->size = 2048;
+        $file->type = 'image/jpeg';
 
         return $file;
     }
@@ -92,7 +92,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function just_url_template_preview_returns_file_url(): void
     {
-        $t    = new JustUrlTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new JustUrlTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertSame($file->url, $t->preview($file));
@@ -121,7 +121,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function markdown_image_template_preview_produces_markdown_syntax(): void
     {
-        $t    = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $preview = $t->preview($file);
@@ -132,7 +132,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function markdown_image_template_preview_embeds_url(): void
     {
-        $t    = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new MarkdownImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->url, $t->preview($file));
@@ -153,10 +153,10 @@ class TemplatesTest extends TestCase
     #[Test]
     public function bbcode_image_template_preview_produces_bbcode_syntax(): void
     {
-        $t    = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
-        $url     = $file->url;
+        $url = $file->url;
         $preview = $t->preview($file);
 
         $this->assertSame("[URL=$url][IMG]{$url}[/IMG][/URL]", $preview);
@@ -165,7 +165,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function bbcode_image_template_preview_contains_url_twice(): void
     {
-        $t    = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new BbcodeImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         // URL appears in both the [URL=…] wrapper and the [IMG]…[/IMG] inner tag
@@ -195,7 +195,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function file_template_bbcode_contains_uuid_and_size_placeholders(): void
     {
-        $t      = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
         $bbcode = $t->bbcode();
 
         $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
@@ -216,7 +216,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function file_template_preview_substitutes_uuid(): void
     {
-        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->uuid, $t->preview($file));
@@ -225,7 +225,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function file_template_preview_substitutes_human_size(): void
     {
-        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->humanSize, $t->preview($file));
@@ -234,7 +234,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function file_template_preview_substitutes_base_name(): void
     {
-        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->base_name, $t->preview($file));
@@ -243,7 +243,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function file_template_preview_contains_no_remaining_placeholders(): void
     {
-        $t    = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $preview = $t->preview($file);
@@ -257,7 +257,7 @@ class TemplatesTest extends TestCase
     public function file_template_returns_a_view(): void
     {
         $view = $this->makeView();
-        $t    = new FileTemplate($this->makeViewFactory($view), $this->makeTranslator());
+        $t = new FileTemplate($this->makeViewFactory($view), $this->makeTranslator());
 
         $this->assertSame($view, $t->template());
     }
@@ -285,7 +285,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_bbcode_contains_uuid_size_and_url_placeholders(): void
     {
-        $t      = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $bbcode = $t->bbcode();
 
         $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
@@ -298,7 +298,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_preview_substitutes_uuid(): void
     {
-        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->uuid, $t->preview($file));
@@ -307,7 +307,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_preview_substitutes_url(): void
     {
-        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->url, $t->preview($file));
@@ -316,7 +316,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_preview_substitutes_human_size(): void
     {
-        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->humanSize, $t->preview($file));
@@ -325,7 +325,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_preview_substitutes_base_name(): void
     {
-        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->base_name, $t->preview($file));
@@ -334,7 +334,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_template_preview_contains_no_remaining_placeholders(): void
     {
-        $t    = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $preview = $t->preview($file);
@@ -349,7 +349,7 @@ class TemplatesTest extends TestCase
     public function image_template_returns_a_view(): void
     {
         $view = $this->makeView();
-        $t    = new ImageTemplate($this->makeViewFactory($view), $this->makeTranslator());
+        $t = new ImageTemplate($this->makeViewFactory($view), $this->makeTranslator());
 
         $this->assertSame($view, $t->template());
     }
@@ -377,7 +377,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_preview_template_bbcode_contains_uuid_and_url_placeholders(): void
     {
-        $t      = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $bbcode = $t->bbcode();
 
         $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
@@ -388,7 +388,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_preview_template_preview_substitutes_uuid(): void
     {
-        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->uuid, $t->preview($file));
@@ -397,7 +397,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_preview_template_preview_substitutes_url(): void
     {
-        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->url, $t->preview($file));
@@ -406,7 +406,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function image_preview_template_preview_substitutes_all_placeholders(): void
     {
-        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $preview = $t->preview($file);
@@ -422,7 +422,7 @@ class TemplatesTest extends TestCase
         // Default alt text is the filename. Users who manually edit the BBCode
         // in their post can override alt= and the formatter will preserve it,
         // since alt={TEXT?} in bbcode() marks it as an accepted optional attribute.
-        $t    = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString("alt={$file->base_name}", $t->preview($file));
@@ -432,7 +432,7 @@ class TemplatesTest extends TestCase
     public function image_preview_template_returns_a_view(): void
     {
         $view = $this->makeView();
-        $t    = new ImagePreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
+        $t = new ImagePreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
 
         $this->assertSame($view, $t->template());
     }
@@ -460,7 +460,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function text_preview_template_bbcode_contains_uuid_url_and_snippet_placeholders(): void
     {
-        $t      = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $bbcode = $t->bbcode();
 
         $this->assertStringContainsString('uuid={IDENTIFIER}', $bbcode);
@@ -474,7 +474,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function text_preview_template_preview_uses_uuid(): void
     {
-        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->uuid, $t->preview($file));
@@ -483,7 +483,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function text_preview_template_preview_uses_url(): void
     {
-        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->url, $t->preview($file));
@@ -492,7 +492,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function text_preview_template_preview_uses_base_name_as_inner_text(): void
     {
-        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString($file->base_name, $t->preview($file));
@@ -501,7 +501,7 @@ class TemplatesTest extends TestCase
     #[Test]
     public function text_preview_template_preview_sets_has_snippet_false(): void
     {
-        $t    = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $this->assertStringContainsString('has_snippet=false', $t->preview($file));
@@ -511,7 +511,7 @@ class TemplatesTest extends TestCase
     public function text_preview_template_returns_a_view(): void
     {
         $view = $this->makeView();
-        $t    = new TextPreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
+        $t = new TextPreviewTemplate($this->makeViewFactory($view), $this->makeTranslator());
 
         $this->assertSame($view, $t->template());
     }
@@ -524,13 +524,13 @@ class TemplatesTest extends TestCase
     public static function allTemplateTags(): array
     {
         return [
-            'just-url'      => ['just-url'],
+            'just-url'       => ['just-url'],
             'markdown-image' => ['markdown-image'],
-            'bbcode-image'  => ['bbcode-image'],
-            'file'          => ['file'],
-            'image'         => ['image'],
-            'image-preview' => ['image-preview'],
-            'text-preview'  => ['text-preview'],
+            'bbcode-image'   => ['bbcode-image'],
+            'file'           => ['file'],
+            'image'          => ['image'],
+            'image-preview'  => ['image-preview'],
+            'text-preview'   => ['text-preview'],
         ];
     }
 
@@ -563,7 +563,7 @@ class TemplatesTest extends TestCase
     #[DataProvider('allTextFormatterTemplates')]
     public function text_formatter_template_preview_substitutes_all_required_placeholders(string $class): void
     {
-        $t    = new $class($this->makeViewFactory(), $this->makeTranslator());
+        $t = new $class($this->makeViewFactory(), $this->makeTranslator());
         $file = $this->makeFile();
 
         $preview = $t->preview($file);


### PR DESCRIPTION
## Summary

This PR adds a comprehensive unit test suite for the template system, fixes a bug the tests uncovered in `ImagePreviewTemplate` / `FormatImagePreview`, and fixes the text preview template for CDN-hosted files.

---

## 1. Unit tests for all 7 templates

**New file:** `tests/unit/Templates/TemplatesTest.php` (48 tests)

Each template (`JustUrl`, `MarkdownImage`, `BbcodeImage`, `File`, `Image`, `ImagePreview`, `TextPreview`) is tested for:

- `tag()` returns the correct slug
- `preview()` substitutes all required placeholders (`{IDENTIFIER}`, `{URL}`, `{SIMPLETEXT1}`, `{SIMPLETEXT2}`) — none remain in the output
- `preview()` embeds the correct file fields (uuid, url, base_name, humanSize)
- TextFormatter templates implement `TextFormatterTemplate`; simple templates do not
- `bbcode()` contains the expected attribute declarations
- `template()` returns the injected View instance
- Template-specific contracts (e.g. `FileTemplate` BBCode has no `url=`, `TextPreviewTemplate` sets `has_snippet=false`)

Cross-template tests:
- All 7 template tags are unique (regression guard against accidental duplicates)
- DataProvider test across all TextFormatter templates: no required placeholder survives into `preview()` output

Tests use lightweight PHPUnit stubs for `ViewFactory`, `View`, and `TranslatorInterface` — no Flarum bootstrap required.

## 2. Unit tests for `FormatImagePreview`

**New file:** `tests/unit/Formatter/FormatImagePreviewTest.php` (6 tests)

Covers the formatter's attribute-rewriting logic:
- `alt` defaults to filename when absent or empty
- `alt` is restored to filename when the legacy `{TEXT?}` placeholder is stored
- User-supplied custom `alt` values are preserved
- `title` is always set to filename
- `url` is updated from the repository (CDN/storage rewrite)

---

## 3. Bug fix: `ImagePreviewTemplate` alt text

**Problem discovered by the tests:**

`ImagePreviewTemplate::preview()` used the inherited `AbstractTextFormatterTemplate::preview()`, which has no substitution rule for `alt`. The BBCode definition:

```
[upl-image-preview uuid={IDENTIFIER} url={URL?} alt={TEXT?}]
```

has no `File` field mapped to `alt`, so `{TEXT?}` was written verbatim into the saved post XML:

```xml
<UPL-IMAGE-PREVIEW uuid="abc123" url="https://..." alt="{TEXT?}"/>
```

`FormatImagePreview` had a workaround that cleared it at render time:

```php
if (Arr::get($attributes, 'alt') === '{TEXT?}') {
    $attributes['alt'] = '';
}
```

This meant every image rendered with `alt=""` — invisible to screen readers and failing accessibility.

**Fix (two parts):**

1. `ImagePreviewTemplate::preview()` now overrides to write `alt={$file->base_name}` for new uploads.
2. `FormatImagePreview` now sets `$attributes['alt'] = $file->base_name` whenever `alt` is absent, empty, or still the legacy `{TEXT?}` literal — covering both new posts and all existing posts in the database. User-supplied custom `alt` values are left untouched.

**User-supplied alt text is preserved:** `alt={TEXT?}` in `bbcode()` marks `alt` as an accepted optional attribute in TextFormatter. Users who manually write `alt=My custom text` in the BBCode will have their value rendered as-is.

---

## 4. Bug fix: text preview template for CDN-hosted files

**Problem:** When a text file was stored on a CDN (different origin to the forum, e.g. `cdn.example.com`), the text preview template immediately entered its error state on page load.

Two root causes:

1. **JS hoisting bug** — the inline `<script>` block used `{ }` to scope variables. Inside a block, `function` declarations are not hoisted the same way as at the top level. `handleError()` was called before it was defined, causing a ReferenceError.

2. **Cross-origin fetch restriction** — the browser cannot `fetch()` a file from a different origin. The code reached the cross-origin branch and called `handleError()` unconditionally, even though the file itself was perfectly valid.

**Fix:**
- Moved `handleError()` definition before its first call site.
- Wrapped `new URL('{@url}')` in a try/catch for malformed URL safety.
- For cross-origin files: hide the expand toggle instead of triggering the error state; a **"Download file"** link (`<a target="_blank">`) is shown in its place, opening the file URL in a new tab.
- For same-origin files: the download link is hidden and existing expand/collapse behaviour is unchanged.
- Added `FormatTextPreview::getUrlForFile()` call to refresh the stored URL from the adapter at render time (mirrors `FormatImagePreview`).
- Added locale key `fof-upload.forum.text_preview.download`.

---

## Files changed

| File | Change |
|---|---|
| `tests/unit/Templates/TemplatesTest.php` | **New** — 48 unit tests across all 7 templates |
| `tests/unit/Formatter/FormatImagePreviewTest.php` | **New** — 6 unit tests for `FormatImagePreview` alt/title/url logic |
| `src/Templates/ImagePreviewTemplate.php` | Override `preview()` to write `alt=$file->base_name` |
| `src/Formatter/ImagePreview/FormatImagePreview.php` | Set `alt` from filename at render time; handles legacy posts |
| `src/Formatter/TextPreview/FormatTextPreview.php` | Refresh URL from adapter at render time |
| `resources/templates/text-preview.blade.php` | Fix JS hoisting bug; cross-origin: hide toggle, show download link |
| `resources/locale/en.yml` | Add `forum.text_preview.download` key |

## Test plan

- [ ] `composer test` — all 54 unit tests pass
- [ ] Upload a new image with the `image-preview` template → `<img>` renders with `alt="filename.jpg"`
- [ ] View an old post (pre-fix) with an image-preview → `alt` shows filename, not `""` or `"{TEXT?}"`
- [ ] Manually set `alt=Custom description` in a post's BBCode → custom alt is preserved in the rendered output
- [ ] Upload a text file with local storage → snippet displays, expand/collapse works
- [ ] Upload a text file with CDN storage → snippet displays, "Download file" button appears and opens the file in a new tab, no error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)