### PR TITLE
[2.x] feat: store image dimensions to prevent layout shifts on lazy-loaded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ An extension that handles file uploads intelligently for your forum.
 - For images:
   - Auto watermarks with proportional scaling, opacity and padding controls.
   - Auto resizing.
+  - Dimension storage (width × height) for JPEG, PNG, and GIF — prevents layout shifts when images lazy-load.
+  - Animated GIF support for resize operations.
 - Mime type to upload adapter mapping.
 - Whitelisting mime types.
 - Uploading on different storage services (local, imgur, AWS S3 for instance).
@@ -89,6 +91,16 @@ When **Watermark images** is enabled, FoF Upload stamps every uploaded JPEG or P
 5. Save — the settings are applied to every new image upload.
 
 > **Backwards compatibility:** Existing installs that used watermarks before these settings were introduced will use the defaults on next upload: 25% width, 100% opacity, 10 px padding. Set padding to `0` to restore the previous flush-edge behaviour.
+
+### Image Dimensions & Layout Shift Prevention
+
+FoF Upload automatically stores the width and height (in pixels) of every JPEG, PNG, and GIF processed at upload time. These are recorded after any resizing or EXIF orientation correction is applied, so they always reflect the **final image as stored**.
+
+The stored dimensions are injected as `width` and `height` HTML attributes on the `<img>` tag rendered by the **Image Preview** template. Modern browsers use these attributes to reserve the correct amount of layout space before the image has loaded, eliminating [Cumulative Layout Shift (CLS)](https://web.dev/cls/) in threads that contain lazy-loaded images.
+
+**No configuration is required** — this happens automatically for all new JPEG, PNG, and GIF uploads. Images uploaded before this feature was added will not have stored dimensions; they continue to render without `width`/`height` attributes and are unaffected.
+
+> **GIF support:** Animated GIF uploads now also benefit from the **Resize images** setting. Watermarks are intentionally not applied to GIFs to avoid palette quality degradation.
 
 ### Storage Configuration
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,41 @@ For ongoing maintenance, a daily cronjob is a sensible setup:
 php flarum fof:upload --map --cleanup --force
 ```
 
+### BackfillImageDimensionsCommand
+
+The `php flarum fof:upload:backfill-dimensions` command retroactively stores `image_width` and `image_height` for existing JPEG, PNG, and GIF uploads that were created before the dimension-storage feature was introduced.
+
+The command downloads each image (using whatever storage backend the file was uploaded to — local, S3, CDN, etc.), reads its dimensions with Intervention Image, and saves them to the database. Images that already have dimensions stored are skipped automatically.
+
+#### Options
+
+| Option | Description |
+|---|---|
+| `--chunk=N` | Process files in batches of N (default: `100`). Reduce this if memory is a concern. |
+| `--dry-run` | Print how many images would be processed without making any changes. |
+
+#### Examples
+
+Preview how many images need backfilling:
+
+```bash
+php flarum fof:upload:backfill-dimensions --dry-run
+```
+
+Run the backfill with the default chunk size:
+
+```bash
+php flarum fof:upload:backfill-dimensions
+```
+
+Run with a smaller chunk size on a large forum:
+
+```bash
+php flarum fof:upload:backfill-dimensions --chunk=25
+```
+
+> **Note:** The command is safe to run multiple times — it only processes images where `image_width` is still `NULL`. If a file is unreachable (e.g. deleted from storage) it is skipped with a warning and the command continues.
+
 ## Testing and Security Measures
 
 FoF Upload includes **automated tests** to ensure:

--- a/extend.php
+++ b/extend.php
@@ -60,7 +60,8 @@ return [
         ->delete('/fof/upload/delete/{uuid}', 'fof-upload.delete', Api\Controllers\DeleteFileController::class),
 
     (new Extend\Console())
-        ->command(Console\MapFilesCommand::class),
+        ->command(Console\MapFilesCommand::class)
+        ->command(Console\BackfillImageDimensionsCommand::class),
 
     (new Extend\Csrf())
         ->exemptRoute('fof-upload.download'),

--- a/migrations/2026_02_22_000000_alter_fof_upload_files_add_image_dimensions.php
+++ b/migrations/2026_02_22_000000_alter_fof_upload_files_add_image_dimensions.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) use ($schema) {
+            if (!$schema->hasColumn('fof_upload_files', 'image_width')) {
+                $table->unsignedInteger('image_width')->nullable();
+            }
+            if (!$schema->hasColumn('fof_upload_files', 'image_height')) {
+                $table->unsignedInteger('image_height')->nullable();
+            }
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) {
+            $table->dropColumn(['image_width', 'image_height']);
+        });
+    },
+];

--- a/resources/less/forum/download.less
+++ b/resources/less/forum/download.less
@@ -1,3 +1,10 @@
+// Ensure width/height HTML attributes used for aspect-ratio hinting don't
+// override CSS scaling. height: auto lets max-width control the display size.
+.FoFUpload--Upl-Image-Preview {
+    height: auto;
+    max-width: 100%;
+}
+
 .fof-download.row {
     margin: 10px auto 0;
     min-height: 280px;

--- a/resources/templates/image-preview.blade.php
+++ b/resources/templates/image-preview.blade.php
@@ -1,1 +1,1 @@
-<img class="FoFUpload--Upl-Image-Preview" src="{@url}" title="{@title}" alt="{@alt}" data-id="{@uuid}" loading="lazy"/>
+<img class="FoFUpload--Upl-Image-Preview" src="{@url}" title="{@title}" alt="{@alt}" data-id="{@uuid}" loading="lazy" width="{@width}" height="{@height}"/>

--- a/src/Console/BackfillImageDimensionsCommand.php
+++ b/src/Console/BackfillImageDimensionsCommand.php
@@ -73,7 +73,7 @@ class BackfillImageDimensionsCommand extends Command
                     $imageData = $response->getBody()->getContents();
                     $image = $imageManager->read($imageData);
 
-                    $file->image_width  = $image->width();
+                    $file->image_width = $image->width();
                     $file->image_height = $image->height();
                     $file->save();
 

--- a/src/Console/BackfillImageDimensionsCommand.php
+++ b/src/Console/BackfillImageDimensionsCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Console;
+
+use FoF\Upload\Downloader\DefaultDownloader;
+use FoF\Upload\File;
+use Illuminate\Console\Command;
+use Intervention\Image\Exceptions\DecoderException;
+use Intervention\Image\ImageManager;
+
+class BackfillImageDimensionsCommand extends Command
+{
+    protected $signature = 'fof:upload:backfill-dimensions
+        {--chunk=100 : Number of images to process per batch}
+        {--dry-run : Report how many images would be processed without making any changes}
+    ';
+
+    protected $description = 'Backfill missing image dimensions (width/height) for existing JPEG, PNG, and GIF uploads';
+
+    public function handle(DefaultDownloader $downloader, ImageManager $imageManager): void
+    {
+        $supportedMimes = ['image/jpeg', 'image/png', 'image/gif'];
+        $chunkSize = max(1, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = File::query()
+            ->whereIn('type', $supportedMimes)
+            ->whereNull('image_width');
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('All eligible images already have dimensions stored. Nothing to do.');
+
+            return;
+        }
+
+        if ($dryRun) {
+            $this->info("Dry run: $total image(s) would be processed.");
+
+            return;
+        }
+
+        $this->info("Processing $total image(s) in chunks of $chunkSize...");
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $updated = 0;
+        $skipped = 0;
+
+        $query->chunkById($chunkSize, function ($files) use ($downloader, $imageManager, $bar, &$updated, &$skipped) {
+            foreach ($files as $file) {
+                try {
+                    $response = $downloader->download($file);
+
+                    if ($response->getStatusCode() !== 200) {
+                        $skipped++;
+                        $bar->advance();
+                        continue;
+                    }
+
+                    $imageData = $response->getBody()->getContents();
+                    $image = $imageManager->read($imageData);
+
+                    $file->image_width  = $image->width();
+                    $file->image_height = $image->height();
+                    $file->save();
+
+                    $updated++;
+                } catch (DecoderException $e) {
+                    $this->newLine();
+                    $this->warn("Skipped {$file->base_name} (uuid: {$file->uuid}): could not decode image — {$e->getMessage()}");
+                    $skipped++;
+                } catch (\Throwable $e) {
+                    $this->newLine();
+                    $this->warn("Skipped {$file->base_name} (uuid: {$file->uuid}): {$e->getMessage()}");
+                    $skipped++;
+                }
+
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Done. Updated: $updated, Skipped: $skipped.");
+    }
+}

--- a/src/File.php
+++ b/src/File.php
@@ -42,6 +42,8 @@ use Illuminate\Support\Str;
  * @property bool                  $hidden
  * @property array                 $matched_post_ids
  * @property bool                  $shared
+ * @property int|null              $image_width
+ * @property int|null              $image_height
  */
 class File extends AbstractModel
 {
@@ -53,6 +55,8 @@ class File extends AbstractModel
         'hidden'                  => 'boolean',
         'shared'                  => 'boolean',
         'created_at'              => \FoF\Upload\Casts\FlexibleDateTime::class,
+        'image_width'             => 'int',
+        'image_height'            => 'int',
     ];
 
     protected $fillable = [
@@ -64,6 +68,8 @@ class File extends AbstractModel
         'uuid',
         'hidden',
         'shared',
+        'image_width',
+        'image_height',
     ];
 
     public static function filesFor(int $userId, User $actor): Builder

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -58,6 +58,11 @@ class FormatImagePreview
                 if (empty($alt) || $alt === '{TEXT?}') {
                     $attributes['alt'] = $file->base_name;
                 }
+
+                if ($file->image_width && $file->image_height) {
+                    $attributes['width']  = $file->image_width;
+                    $attributes['height'] = $file->image_height;
+                }
             }
 
             return $attributes;

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -60,7 +60,7 @@ class FormatImagePreview
                 }
 
                 if ($file->image_width && $file->image_height) {
-                    $attributes['width']  = $file->image_width;
+                    $attributes['width'] = $file->image_width;
                     $attributes['height'] = $file->image_height;
                 }
             }

--- a/src/Listeners/AddImageProcessor.php
+++ b/src/Listeners/AddImageProcessor.php
@@ -31,10 +31,6 @@ class AddImageProcessor
 
     protected function validateMime(string $mime): bool
     {
-        if ($mime == 'image/jpeg' || $mime == 'image/png' || $mime == 'image/gif' || $mime == 'image/svg+xml') {
-            return true;
-        }
-
-        return false;
+        return in_array($mime, ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'], true);
     }
 }

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -67,7 +67,7 @@ class ImageProcessor implements Processable
         @file_put_contents($upload->getRealPath(), $encoded->toString());
 
         // Store dimensions so the browser can reserve layout space before the image loads.
-        $file->image_width  = $image->width();
+        $file->image_width = $image->width();
         $file->image_height = $image->height();
     }
 

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -37,32 +37,38 @@ class ImageProcessor implements Processable
 
     public function process(File $file, UploadedFile $upload, string $mimeType): void
     {
-        if ($mimeType === 'image/jpeg' || $mimeType === 'image/png') {
-            try {
-                $image = $this->imageManager->read($upload->getRealPath());
-            } catch (RuntimeException $e) {
-                throw new ValidationException(['upload' => 'Corrupted image']);
-            }
-
-            if ($this->settings->get('fof-upload.mustResize')) {
-                $this->resize($image);
-            }
-
-            if ($this->settings->get('fof-upload.addsWatermarks')) {
-                $this->watermark($image);
-            }
-
-            $image->orient();
-
-            $encoded = $mimeType === 'image/jpeg'
-                ? $image->toJpeg(quality: 90)
-                : $image->toPng();
-
-            @file_put_contents(
-                $upload->getRealPath(),
-                $encoded->toString()
-            );
+        if (!in_array($mimeType, ['image/jpeg', 'image/png', 'image/gif'], true)) {
+            return;
         }
+
+        try {
+            $image = $this->imageManager->read($upload->getRealPath());
+        } catch (RuntimeException $e) {
+            throw new ValidationException(['upload' => 'Corrupted image']);
+        }
+
+        if ($this->settings->get('fof-upload.mustResize')) {
+            $this->resize($image);
+        }
+
+        // Watermarks are not applied to GIFs — palette reduction causes quality degradation.
+        if ($this->settings->get('fof-upload.addsWatermarks') && $mimeType !== 'image/gif') {
+            $this->watermark($image);
+        }
+
+        $image->orient();
+
+        $encoded = match ($mimeType) {
+            'image/jpeg' => $image->toJpeg(quality: 90),
+            'image/gif'  => $image->toGif(),
+            default      => $image->toPng(),
+        };
+
+        @file_put_contents($upload->getRealPath(), $encoded->toString());
+
+        // Store dimensions so the browser can reserve layout space before the image loads.
+        $file->image_width  = $image->width();
+        $file->image_height = $image->height();
     }
 
     protected function resize(ImageInterface $image): void

--- a/tests/unit/Formatter/FormatImagePreviewTest.php
+++ b/tests/unit/Formatter/FormatImagePreviewTest.php
@@ -134,4 +134,31 @@ class FormatImagePreviewTest extends TestCase
 
         $this->assertStringContainsString('https://cdn.example.com/photo.jpg', $result);
     }
+
+    #[Test]
+    public function injects_width_and_height_when_file_has_dimensions(): void
+    {
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file->image_width  = 1920;
+        $file->image_height = 1080;
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringContainsString('width="1920"', $result);
+        $this->assertStringContainsString('height="1080"', $result);
+    }
+
+    #[Test]
+    public function does_not_inject_dimensions_when_file_has_none(): void
+    {
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        // image_width / image_height are not set (null)
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringNotContainsString('width="1', $result);
+        $this->assertStringNotContainsString('height="1', $result);
+    }
 }

--- a/tests/unit/Formatter/FormatImagePreviewTest.php
+++ b/tests/unit/Formatter/FormatImagePreviewTest.php
@@ -139,7 +139,7 @@ class FormatImagePreviewTest extends TestCase
     public function injects_width_and_height_when_file_has_dimensions(): void
     {
         $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
-        $file->image_width  = 1920;
+        $file->image_width = 1920;
         $file->image_height = 1080;
         $formatter = new FormatImagePreview($this->makeRepository($file));
 


### PR DESCRIPTION
Fixes #323

## Summary

Uploaded images cause Cumulative Layout Shift (CLS) — when `loading="lazy"` images are rendered without explicit `width`/`height` attributes, the browser reserves no space before they load, causing posts to jump as images pop in.

The fix stores image dimensions at upload time and injects them as `width`/`height` HTML attributes on the `<img>` tag. The browser uses these to reserve the correct layout space before the image loads. A CSS fix (`height: auto`) ensures the attributes serve only as an aspect-ratio hint and don't override the forum's responsive scaling.

Supersedes the approach in [1.x PR #441](https://github.com/FriendsOfFlarum/upload/pull/441) with a cleaner 2.x implementation. Also expands image processing to animated GIFs, and adds a console command to backfill dimensions for existing uploads.

---

## What changed

### 1. Image dimension storage (layout shift fix)

- **New migration** adds nullable `image_width` and `image_height` columns to `fof_upload_files`
- **`ImageProcessor::process()`** captures `$image->width()` and `$image->height()` after all transformations (resize → watermark → orient), so stored values always reflect the **final image as written to disk**
  - If resize is enabled: stored dimensions match the resized output, not the original upload
  - EXIF orientation via `orient()` can swap axes — dimensions are read after, so they're always visually correct
- **`UploadHandler`** already calls `$file->save()` immediately after `WillBeUploaded` fires, so no extra save call is needed
- **`FormatImagePreview`** injects `width`/`height` as XML attributes when they're present on the file record
- **`image-preview.blade.php`** emits `width="{@width}" height="{@height}"` on the `<img>` tag

### 2. CSS fix (`height: auto`)

Without `height: auto`, the `height` HTML attribute is treated as a fixed pixel value. When the forum's CSS scales the image down via `max-width`, the height stays fixed — stretching portrait images. Adding `height: auto` to `.FoFUpload--Upl-Image-Preview` ensures both axes scale together, and the `width`/`height` attributes serve only as the aspect-ratio hint they're intended to be.

### 3. GIF processing

`ImageProcessor::process()` previously skipped GIFs entirely. Intervention Image v3 supports animated GIFs, so:
- GIFs now go through resize (if enabled) and `orient()`
- GIFs are encoded with `toGif()` to preserve animation
- Watermarks are **not** applied to GIFs — overlaying a semi-opaque PNG watermark onto a GIF's limited palette produces significant quality degradation
- Dimension capture applies to GIFs too

### 4. Backfill command for existing images

New command: `php flarum fof:upload:backfill-dimensions`

Retroactively stores dimensions for existing JPEG, PNG, and GIF uploads that predate this feature:

- Downloads each file via `DefaultDownloader` — works transparently for local, S3, CDN, and private-shared storage
- Reads dimensions from the downloaded bytes via Intervention Image (no file-path assumptions)
- Only processes files where `image_width IS NULL` — idempotent, safe to re-run
- Configurable chunk size (`--chunk=N`, default 100) to control memory use on large installs
- Progress bar with per-file skip warnings for unreachable/unreadable images
- `--dry-run` option to preview count without making any changes

```bash
# Preview
php flarum fof:upload:backfill-dimensions --dry-run

# Run (default chunk size)
php flarum fof:upload:backfill-dimensions

# Run with smaller chunks on a large forum
php flarum fof:upload:backfill-dimensions --chunk=25
```

### 5. Cleanup

`AddImageProcessor::validateMime()` replaced equivalent if/else chain with `in_array()`.

---

## Why not the 1.x approach

The 1.x PR adds a separate `fof_upload_image_metadata` table, reads the image from its final stored path at `WasSaved` time (by which point the temp file is already cleaned up — fragile for CDN adapters), has a dead-code `validateMime()` that always returns `true`, and disables s9e's `DisallowUnsafeDynamicCSS` security check just to use CSS `aspect-ratio`. None of that is needed here.

---

## Backwards compatibility

- Existing DB rows have `image_width = null` / `image_height = null` — old posts render `width="" height=""` which browsers silently ignore; no visual change
- New JPEG/PNG/GIF uploads automatically get dimensions stored and rendered
- Other image types (SVG, WebP, AVIF, BMP) continue to work; they get null dimensions (graceful degradation)
- Run `fof:upload:backfill-dimensions` after deploying to retroactively fix old images

---

## Files changed

| File | Change |
|---|---|
| `migrations/2026_02_22_000000_alter_fof_upload_files_add_image_dimensions.php` | **New** — nullable `image_width`, `image_height` on `fof_upload_files` |
| `src/File.php` | Add columns to `$fillable`, `$casts`, PHPDoc |
| `src/Processors/ImageProcessor.php` | Expand to jpeg/png/gif; capture dims after all transforms |
| `src/Listeners/AddImageProcessor.php` | Clean up `validateMime()` with `in_array()` |
| `src/Formatter/ImagePreview/FormatImagePreview.php` | Inject `width`/`height` attributes when present |
| `resources/templates/image-preview.blade.php` | Add `width="{@width}" height="{@height}"` to `<img>` |
| `resources/less/forum/download.less` | Add `height: auto; max-width: 100%` to `.FoFUpload--Upl-Image-Preview` |
| `src/Console/BackfillImageDimensionsCommand.php` | **New** — backfill command |
| `extend.php` | Register backfill command |
| `tests/unit/Formatter/FormatImagePreviewTest.php` | Add 2 tests: dims injected when present; absent when null |
| `README.md` | Document image dimensions feature, GIF support, and backfill command |

## Test plan

- [ ] `composer test` — all 86 unit + 85 integration tests pass
- [ ] Upload a JPEG/PNG with the image-preview template → rendered `<img>` has `width="NNN" height="NNN"`
- [ ] Upload a portrait photo (e.g. from a phone) → displays at correct proportions, not stretched
- [ ] Upload with resize enabled on a large image → stored dimensions match resized output
- [ ] Upload an animated GIF → renders correctly; dimensions stored; no watermark applied
- [ ] Upload an SVG/WebP → renders without meaningful width/height, no error
- [ ] View an old post (pre-migration) → renders normally, no breakage
- [ ] Run `fof:upload:backfill-dimensions --dry-run` → shows count, makes no changes
- [ ] Run `fof:upload:backfill-dimensions` → dimensions populated; re-run reports nothing to do
- [ ] In a thread with many images, scroll quickly — no layout shift as images lazy-load

🤖 Generated with [Claude Code](https://claude.com/claude-code)