### PR TITLE
[2.x] fix: store correct adapter key in upload_method for third-party adapters

### DIFF
--- a/src/Adapters/Flysystem.php
+++ b/src/Adapters/Flysystem.php
@@ -25,6 +25,14 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 abstract class Flysystem implements UploadAdapter
 {
     /**
+     * The canonical key under which this adapter is registered in Manager.
+     * Set by Manager::instantiate() after construction so that Util::setMethod()
+     * can store the correct key in File::upload_method without guessing from
+     * the class name (which breaks third-party adapters with custom keys).
+     */
+    public string $adapterKey = '';
+
+    /**
      * @var array
      */
     protected $meta;

--- a/src/Adapters/Imgur.php
+++ b/src/Adapters/Imgur.php
@@ -21,6 +21,14 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Imgur implements UploadAdapter
 {
+    /**
+     * The canonical key under which this adapter is registered in Manager.
+     * Set by Manager::instantiate() after construction.
+     *
+     * @see Flysystem::$adapterKey
+     */
+    public string $adapterKey = '';
+
     public function __construct(
         protected Guzzle $api
     ) {

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -83,7 +83,16 @@ class Manager
             throw new ValidationException(['upload' => "Cannot instantiate adapter $adapter"]);
         }
 
-        return $driver ?? $this->{$method}($this->util);
+        $instance = $driver ?? $this->{$method}($this->util);
+
+        // Stamp the canonical registration key so Util::setMethod() can store it
+        // in File::upload_method without deriving it from the class name.
+        // This is the only place where the registered key ($adapter) is known.
+        if (property_exists($instance, 'adapterKey')) {
+            $instance->adapterKey = $adapter;
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Helpers/Util.php
+++ b/src/Helpers/Util.php
@@ -301,13 +301,20 @@ class Util
             return 'private-shared';
         }
 
+        // Prefer the canonical key stamped by Manager::instantiate(), which is
+        // always the exact key used during adapter registration. This handles
+        // third-party adapters whose class name differs from their registration
+        // key (e.g. class BlomstraObjectStorage registered as 'blomstra').
+        if (property_exists($adapter, 'adapterKey') && $adapter->adapterKey !== '') {
+            return $adapter->adapterKey;
+        }
+
+        // Fallback for adapters constructed outside Manager (should be rare).
         $className = Str::afterLast($adapter::class, '\\');
-        // Map adapter class names to canonical Manager keys
-        $canonical = match ($className) {
+
+        return match ($className) {
             'AwsS3' => 'aws-s3',
             default => Str::lower($className),
         };
-
-        return $canonical;
     }
 }

--- a/tests/unit/Adapters/ManagerTest.php
+++ b/tests/unit/Adapters/ManagerTest.php
@@ -201,7 +201,9 @@ class ManagerTest extends TestCase
         $url = m::mock(UrlGenerator::class);
 
         $thirdPartyAdapter = new class($fsAdapter, $settings, $url) extends \FoF\Upload\Adapters\Flysystem {
-            protected function generateUrl(\FoF\Upload\File $file): void {}
+            protected function generateUrl(\FoF\Upload\File $file): void
+            {
+            }
         };
 
         // Manager::adapters() fires Collecting — use andReturnUsing to add the 'blomstra' key.

--- a/tests/unit/Adapters/ManagerTest.php
+++ b/tests/unit/Adapters/ManagerTest.php
@@ -160,4 +160,61 @@ class ManagerTest extends TestCase
             rmdir($tempDir);
         }
     }
+
+    #[Test]
+    public function instantiate_stamps_adapter_key_on_local_adapter()
+    {
+        $this->events->shouldReceive('dispatch')->once();
+        $this->events->shouldReceive('until')->once()->andReturn(null);
+
+        $tempDir = sys_get_temp_dir().'/fof-upload-test-'.uniqid();
+        mkdir($tempDir, 0777, true);
+        $this->paths->public = $tempDir;
+
+        $this->settings->shouldReceive('get')->andReturn(null);
+        $this->url->shouldReceive('to')->andReturnSelf();
+        $this->url->shouldReceive('route')->andReturn('http://example.com');
+
+        $adapter = $this->manager->instantiate('local');
+
+        $this->assertSame('local', $adapter->adapterKey);
+
+        // Clean up
+        if (is_dir($tempDir.'/assets/files')) {
+            rmdir($tempDir.'/assets/files');
+        }
+        if (is_dir($tempDir.'/assets')) {
+            rmdir($tempDir.'/assets');
+        }
+        if (is_dir($tempDir)) {
+            rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function instantiate_stamps_adapter_key_on_third_party_adapter_from_event()
+    {
+        // Simulate a third-party adapter registered under the key 'blomstra' that is
+        // returned by a listener on the Instantiate event (not via a Manager method).
+        $fsAdapter = m::mock(\League\Flysystem\FilesystemAdapter::class);
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $url = m::mock(UrlGenerator::class);
+
+        $thirdPartyAdapter = new class($fsAdapter, $settings, $url) extends \FoF\Upload\Adapters\Flysystem {
+            protected function generateUrl(\FoF\Upload\File $file): void {}
+        };
+
+        // Manager::adapters() fires Collecting — use andReturnUsing to add the 'blomstra' key.
+        $this->events->shouldReceive('dispatch')->once()->andReturnUsing(function ($event) {
+            if ($event instanceof \FoF\Upload\Events\Adapter\Collecting) {
+                $event->adapters->put('blomstra', true);
+            }
+        });
+        // Manager::instantiate() fires Instantiate — listener returns the third-party adapter.
+        $this->events->shouldReceive('until')->once()->andReturn($thirdPartyAdapter);
+
+        $adapter = $this->manager->instantiate('blomstra');
+
+        $this->assertSame('blomstra', $adapter->adapterKey);
+    }
 }

--- a/tests/unit/Helpers/UtilSetMethodTest.php
+++ b/tests/unit/Helpers/UtilSetMethodTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\unit\Helpers;
+
+use FoF\Upload\Adapters\AwsS3;
+use FoF\Upload\Adapters\Imgur;
+use FoF\Upload\Adapters\Local;
+use FoF\Upload\Contracts\UploadAdapter;
+use FoF\Upload\Helpers\Util;
+use League\Flysystem\FilesystemAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Util::setMethod().
+ *
+ * setMethod() must store the canonical Manager registration key in
+ * File::upload_method, not a class-name-derived guess.  Manager::instantiate()
+ * stamps the key on the adapter as $adapterKey so setMethod() can read it
+ * directly, handling third-party adapters whose class name differs from their
+ * registration key.
+ */
+class UtilSetMethodTest extends TestCase
+{
+    private function makeUtil(): Util
+    {
+        return $this->getMockBuilder(Util::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+    }
+
+    private function makeFlysystemAdapter(string $adapterKey = ''): Local
+    {
+        $adapter = new Local(
+            $this->createStub(FilesystemAdapter::class),
+            $this->createStub(\Flarum\Settings\SettingsRepositoryInterface::class),
+            $this->createStub(\Flarum\Http\UrlGenerator::class)
+        );
+        $adapter->adapterKey = $adapterKey;
+
+        return $adapter;
+    }
+
+    private function makeImgurAdapter(string $adapterKey = ''): Imgur
+    {
+        $adapter = new Imgur($this->createStub(\GuzzleHttp\Client::class));
+        $adapter->adapterKey = $adapterKey;
+
+        return $adapter;
+    }
+
+    // ---------------------------------------------------------------------------
+
+    #[Test]
+    public function returns_private_shared_when_no_adapter_given(): void
+    {
+        $util = $this->makeUtil();
+        $this->assertSame('private-shared', $util->setMethod(null));
+    }
+
+    #[Test]
+    public function uses_adapter_key_when_set_on_local_adapter(): void
+    {
+        $util = $this->makeUtil();
+        $adapter = $this->makeFlysystemAdapter('local');
+
+        $this->assertSame('local', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function uses_adapter_key_when_set_on_aws_s3_adapter(): void
+    {
+        $util = $this->makeUtil();
+        $adapter = new AwsS3(
+            $this->createStub(FilesystemAdapter::class),
+            $this->createStub(\Flarum\Settings\SettingsRepositoryInterface::class),
+            $this->createStub(\Flarum\Http\UrlGenerator::class)
+        );
+        $adapter->adapterKey = 'aws-s3';
+
+        $this->assertSame('aws-s3', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function uses_adapter_key_for_third_party_adapter_with_custom_key(): void
+    {
+        // Simulate BlomstraObjectStorage registered under 'blomstra'.
+        // Without the fix, setMethod() would have returned 'local' or a class-derived
+        // guess; with the fix it returns exactly the key stamped by Manager::instantiate().
+        $util = $this->makeUtil();
+        $adapter = $this->makeFlysystemAdapter('blomstra');
+
+        $this->assertSame('blomstra', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function uses_adapter_key_for_imgur(): void
+    {
+        $util = $this->makeUtil();
+        $adapter = $this->makeImgurAdapter('imgur');
+
+        $this->assertSame('imgur', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function falls_back_to_class_name_derivation_when_adapter_key_is_empty(): void
+    {
+        // adapterKey is '' (adapter constructed outside Manager).
+        $util = $this->makeUtil();
+        $adapter = $this->makeFlysystemAdapter(''); // no key stamped
+
+        // Fallback: class is Local → 'local'
+        $this->assertSame('local', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function falls_back_correctly_for_aws_s3_class_name(): void
+    {
+        // Without adapterKey, AwsS3 class name → 'aws-s3' via the match rule.
+        $util = $this->makeUtil();
+        $adapter = new AwsS3(
+            $this->createStub(FilesystemAdapter::class),
+            $this->createStub(\Flarum\Settings\SettingsRepositoryInterface::class),
+            $this->createStub(\Flarum\Http\UrlGenerator::class)
+        );
+        // adapterKey defaults to ''
+
+        $this->assertSame('aws-s3', $util->setMethod($adapter));
+    }
+
+    #[Test]
+    public function falls_back_correctly_for_imgur_class_name(): void
+    {
+        $util = $this->makeUtil();
+        $adapter = $this->makeImgurAdapter('');
+
+        $this->assertSame('imgur', $util->setMethod($adapter));
+    }
+}

--- a/tests/unit/Helpers/UtilSetMethodTest.php
+++ b/tests/unit/Helpers/UtilSetMethodTest.php
@@ -15,7 +15,6 @@ namespace FoF\Upload\Tests\unit\Helpers;
 use FoF\Upload\Adapters\AwsS3;
 use FoF\Upload\Adapters\Imgur;
 use FoF\Upload\Adapters\Local;
-use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\Helpers\Util;
 use League\Flysystem\FilesystemAdapter;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
## Summary

- `Util::setMethod()` was deriving the `upload_method` key from the adapter class name (e.g. `BlomstraObjectStorage` → `'blomstraobjectstorage'`), but `Manager::instantiate()` looks up adapters by their registered key (e.g. `'blomstra'`)
- This mismatch caused `ValidationException: No adapter configured for <classname>` on every subsequent adapter lookup — URL generation, file cleanup, GDPR export, and the thumbnail backfill command all failed for third-party adapters
- Fix: `Manager::instantiate()` stamps the canonical registration key on the returned instance as `$adapterKey`; `Util::setMethod()` reads this property first, falling back to the class-name derivation only for adapters constructed outside `Manager`
- No changes to the `Collecting` or `Instantiate` event APIs — fully backwards compatible

Fixes #431

## Test plan

- [ ] `composer test` passes (104 unit, 85 integration)
- [ ] New `UtilSetMethodTest` covers: correct key used when `adapterKey` is stamped, fallback for unstamped adapters, `private-shared` when no adapter
- [ ] New `ManagerTest` cases verify `adapterKey` is stamped for built-in (`local`) and event-based third-party adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)