### PR TITLE
feat: delete orphaned files when their post is deleted

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -19,6 +19,7 @@ use Flarum\Extend;
 use Flarum\Gdpr\Extend\UserData;
 use Flarum\Post\Event\Posted;
 use Flarum\Post\Event\Revised;
+use Flarum\Post\Post;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\Settings\Event\Deserializing;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -132,6 +133,8 @@ return [
         ->listen(Revised::class, Listeners\LinkFilesToPostOnSave::class)
         ->listen(WillBeUploaded::class, Listeners\AddImageProcessor::class),
 
+    (new Extend\ModelObserver(Post::class, Listeners\CleanUpFilesOnPostDelete::class)),
+
     (new Extend\Filesystem())
         ->disk('private-shared', Extenders\PrivateSharedDiskConfig::class),
 
@@ -162,7 +165,8 @@ return [
         ->default('fof-upload.svgAnimateAllowed', false)
         ->default('fof-upload.generateThumbnails', true)
         ->default('fof-upload.thumbnailWebp', true)
-        ->default('fof-upload.thumbnailMaxWidth', 1000),
+        ->default('fof-upload.thumbnailMaxWidth', 1000)
+        ->default('fof-upload.deleteFilesOnPostDelete', false),
 
     new Extenders\AddPostDownloadTags(),
     new Extenders\CreateStorageFolder('tmp'),

--- a/extend.php
+++ b/extend.php
@@ -133,7 +133,7 @@ return [
         ->listen(Revised::class, Listeners\LinkFilesToPostOnSave::class)
         ->listen(WillBeUploaded::class, Listeners\AddImageProcessor::class),
 
-    (new Extend\ModelObserver(Post::class, Listeners\CleanUpFilesOnPostDelete::class)),
+    new Extend\ModelObserver(Post::class, Listeners\CleanUpFilesOnPostDelete::class),
 
     (new Extend\Filesystem())
         ->disk('private-shared', Extenders\PrivateSharedDiskConfig::class),

--- a/js/src/admin/components/UploadPage.tsx
+++ b/js/src/admin/components/UploadPage.tsx
@@ -120,6 +120,7 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
       'addsWatermarks',
       'disableHotlinkProtection',
       'disableDownloadLogging',
+      'deleteFilesOnPostDelete',
       'awsS3UsePathStyleEndpoint',
       'svgAnimateAllowed',
     ];
@@ -477,6 +478,13 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
                 <div className="Form-group">
                   <Switch state={this.values.disableDownloadLogging() || false} onchange={this.values.disableDownloadLogging}>
                     {app.translator.trans('fof-upload.admin.labels.disable-download-logging.toggle')}
+                  </Switch>
+                </div>
+                <legend>{app.translator.trans('fof-upload.admin.labels.delete-files-on-post-delete.title')}</legend>
+                <p className="helpText">{app.translator.trans('fof-upload.admin.help_texts.delete-files-on-post-delete')}</p>
+                <div className="Form-group">
+                  <Switch state={this.values.deleteFilesOnPostDelete() || false} onchange={this.values.deleteFilesOnPostDelete}>
+                    {app.translator.trans('fof-upload.admin.labels.delete-files-on-post-delete.toggle')}
                   </Switch>
                 </div>
               </fieldset>

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -23,6 +23,10 @@ fof-upload:
       title: Upload
       description: Set up uploading services and preferences.
     help_texts:
+      delete-files-on-post-delete: |
+        When enabled, files exclusively attached to a deleted post are immediately removed from storage and the database.
+        Files referenced by multiple posts are not affected. When disabled (default), orphaned files are only removed
+        when the cleanup command is run manually: php flarum fof:upload --cleanup
       disable-download-logging: |
         Disable logging every download made by users of your forum. Keeping it enabled allows you to view the number of downloads and other metrics in the nearby future.
       disable-hotlink-protection: |
@@ -67,6 +71,9 @@ fof-upload:
         use_path_style_endpoint: Use path style endpoint
         acl: Access Control List (ACL)
         custom_url: Custom S3 URL
+      delete-files-on-post-delete:
+        title: File cleanup on post deletion
+        toggle: Delete uploaded files when the containing post is deleted
       disable-download-logging:
         title: Disable logging downloads
         toggle: Disable

--- a/src/Listeners/CleanUpFilesOnPostDelete.php
+++ b/src/Listeners/CleanUpFilesOnPostDelete.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Listeners;
+
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Upload\Adapters\Manager;
+
+class CleanUpFilesOnPostDelete
+{
+    public function __construct(
+        private SettingsRepositoryInterface $settings,
+        private Manager $manager,
+    ) {
+    }
+
+    /**
+     * Fires before the post is deleted (and before the DB cascade removes pivot rows),
+     * so we can still read which files are associated with this post.
+     */
+    public function deleting(Post $post): void
+    {
+        if (!$this->settings->get('fof-upload.deleteFilesOnPostDelete', false)) {
+            return;
+        }
+
+        // Load files now — before the cascade wipes the fof_upload_file_posts rows.
+        $files = $post->files()
+            ->where('shared', false)
+            ->get();
+
+        foreach ($files as $file) {
+            // Only delete if this post is the file's sole association.
+            // posts()->count() is still accurate here because the cascade hasn't run yet.
+            if ($file->posts()->count() !== 1) {
+                // File is referenced by other posts — leave it; cascade removes only this pivot row.
+                continue;
+            }
+
+            $adapter = $this->manager->instantiate($file->upload_method);
+
+            if ($adapter->delete($file)) {
+                $file->delete();
+            }
+            // If storage deletion fails we leave the DB record intact — no silent data loss.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- When a post is deleted, `fof_upload_file_posts` pivot rows are cascade-deleted by the DB, but the actual `fof_upload_files` records and physical files on storage remained orphaned indefinitely
- Adds a `ModelObserver` on `Post` that hooks in *before* deletion (while pivot rows still exist) to optionally clean up exclusively-associated files
- New admin setting `deleteFilesOnPostDelete` (off by default) — when enabled, files used only in the deleted post are removed from storage and the DB immediately; files referenced by multiple posts are left untouched
- When the setting is off, the existing manual cleanup command (`php flarum fof:upload --cleanup`) continues to handle orphaned files as before

## Changes

- `src/Listeners/CleanUpFilesOnPostDelete.php` — new model observer
- `extend.php` — `ModelObserver` extender + settings default
- `js/src/admin/components/UploadPage.tsx` — admin toggle
- `resources/locale/en.yml` — locale keys

## Test plan

- [ ] Enable the setting; upload a file in a post; delete the post → file gone from DB and storage
- [ ] File referenced in two posts: delete one → file survives, only pivot row removed
- [ ] Shared file (`shared = true`): delete post → file survives
- [ ] Setting off: delete post → files remain; `php flarum fof:upload --cleanup` removes them
- [ ] Storage adapter delete failure → DB record preserved (no silent data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)