### PR TITLE
[2.x] fix: image preview shows empty src in composer preview

### DIFF
--- a/src/Templates/ImagePreviewTemplate.php
+++ b/src/Templates/ImagePreviewTemplate.php
@@ -53,6 +53,8 @@ class ImagePreviewTemplate extends AbstractTextFormatterTemplate
 
     public function preview(File $file): string
     {
-        return "[upl-image-preview uuid={$file->uuid} url={$file->url} alt={$file->base_name}]";
+        $thumbnailUrl = $file->thumbnail_url ?: $file->url;
+
+        return "[upl-image-preview uuid={$file->uuid} url={$file->url} alt={$file->base_name} thumbnail_url={$thumbnailUrl}]";
     }
 }


### PR DESCRIPTION
## Problem

After the thumbnail feature (PR #465), uploading an image with the `image-preview` template showed a broken image (`src=""`) in the composer live preview:

```html
<img class="FoFUpload--Upl-Image-Preview" src="" ...>
```

## Root cause

The `preview()` method in `ImagePreviewTemplate` generates the BBCode string that the **JavaScript** TextFormatter renderer uses for the composer preview (the live preview while typing, before the post is submitted). It was not including `thumbnail_url`:

```php
// Before
return "[upl-image-preview uuid={$file->uuid} url={$file->url} alt={$file->base_name}]";
```

The image-preview blade template uses `{@thumbnail_url}` as the `<img src>`. Since `thumbnail_url` was absent from the BBCode, the JS renderer set `src=""`.

The PHP `FormatImagePreview` renderer (which properly injects `thumbnail_url`) only runs at post save/render time — not during the composer live preview.

## Fix

Include `thumbnail_url` in the preview BBCode, using `$file->thumbnail_url` (the stored thumbnail) falling back to `$file->url` (the original file URL):

```php
$thumbnailUrl = $file->thumbnail_url ?: $file->url;
return "[upl-image-preview uuid={$file->uuid} url={$file->url} alt={$file->base_name} thumbnail_url={$thumbnailUrl}]";
```

Forums without thumbnails generated (e.g. before running the backfill command) will show the full-resolution image in the preview, matching the pre-thumbnail behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)