### PR TITLE
[2.x] fix: clipboard paste upload broken in 2.x

### DIFF
--- a/js/src/forum/addUploadButton.ts
+++ b/js/src/forum/addUploadButton.ts
@@ -58,10 +58,17 @@ export default function addUploadButton(): void {
     if (dragAndDropTarget) {
       this.dragAndDrop = new DragAndDrop((files) => this.uploader.upload(files), dragAndDropTarget);
     }
+  });
+
+  // PasteClipboard must be attached in onbuild, not oncreate.
+  // The .TextEditor-editor element (the textarea) is created by BasicEditorDriver
+  // inside onbuild() — it does not exist yet when oncreate runs.
+  extend(TextEditor.prototype, 'onbuild', function (this: any) {
+    if (!app.forum.attribute('fof-upload.canUpload')) return;
 
     const editorEl = this.$('.TextEditor-editor')[0];
     if (editorEl) {
-      new PasteClipboard((files) => this.uploader.upload(files), editorEl);
+      this.fofPasteClipboard = new PasteClipboard((files) => this.uploader.upload(files), editorEl);
     }
   });
 


### PR DESCRIPTION
## Problem

Copy an image to the clipboard (e.g. take a screenshot), open the Flarum composer, paste — nothing happens. Clipboard paste upload worked in 1.x but is broken in 2.x.

## Root cause

In Flarum 2.x, `TextEditor` has an asynchronous build lifecycle:

```
oncreate() → _load() [async] → setTimeout 50ms → onbuild()
                                                    └─ BasicEditorDriver creates the <textarea>
                                                       and appends it with class .TextEditor-editor
```

The paste listener was being attached in the `oncreate` extension:

```ts
const editorEl = this.$('.TextEditor-editor')[0]; // undefined — element doesn't exist yet!
if (editorEl) {
  new PasteClipboard(..., editorEl);             // never reached
}
```

`this.$('.TextEditor-editor')[0]` returns `undefined` because the textarea is only created later inside `onbuild()` by `BasicEditorDriver`. The `if (editorEl)` guard silently swallowed this — `PasteClipboard` was never instantiated.

## Fix

Move `PasteClipboard` instantiation to an `onbuild` extension. By that point the textarea exists in the DOM:

```ts
extend(TextEditor.prototype, 'onbuild', function (this: any) {
  if (!app.forum.attribute('fof-upload.canUpload')) return;

  const editorEl = this.$('.TextEditor-editor')[0];
  if (editorEl) {
    this.fofPasteClipboard = new PasteClipboard((files) => this.uploader.upload(files), editorEl);
  }
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)