### PR TITLE
[1.x] fix: handle missing local files in DefaultDownloader and GDPR export

### DIFF
--- a/src/Data/Uploads.php
+++ b/src/Data/Uploads.php
@@ -31,7 +31,12 @@ class Uploads extends Type
             ->where('actor_id', $this->user->id)
             ->orderBy('id', 'asc')
             ->each(function (File $file) use ($downloader, &$dataExport) {
-                $fileContent = $downloader->download($file)->getBody()->getContents();
+                try {
+                    $fileContent = $downloader->download($file)->getBody()->getContents();
+                } catch (\Exception $e) {
+                    // Skip files that cannot be retrieved (e.g. missing from disk).
+                    return;
+                }
                 $dataExport[] = ["uploads/{$file->path}" => $fileContent];
             });
 

--- a/src/Downloader/DefaultDownloader.php
+++ b/src/Downloader/DefaultDownloader.php
@@ -58,6 +58,10 @@ class DefaultDownloader implements Downloader
     {
         $file_contents = @file_get_contents(resolve(Paths::class)->public.'/assets/files/'.$file->path);
 
+        if ($file_contents === false) {
+            throw new InvalidDownloadException("Local file not found on disk: {$file->path}");
+        }
+
         return $this->mutateHeaders(new TextResponse($file_contents), $file);
     }
 


### PR DESCRIPTION
## Summary

- `retrieveFromLocal()` uses `@file_get_contents()` which returns `false` when the file is missing from disk. This `false` was passed directly to `new TextResponse()`, throwing `Laminas\Diactoros\Exception\InvalidArgumentException` since `TextResponse` only accepts strings.
- `Uploads::export()` had no error handling around the download call, so a single missing file would abort the entire GDPR data export job with an unhandled exception.

## Changes

- **`DefaultDownloader::retrieveFromLocal()`** — guard against a `false` return from `file_get_contents` and throw `InvalidDownloadException` instead (consistent with how `retrieveFromExternal` handles errors)
- **`Uploads::export()`** — wrap the per-file download in a `try/catch` so missing or unreadable files are skipped gracefully rather than aborting the whole export

## Test plan

- [ ] Trigger a GDPR data export for a user who has uploads where one or more local files are missing from disk — export should complete successfully, skipping the missing files
- [ ] Trigger a normal file download for a missing local file — should receive an appropriate error rather than a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)