### PR TITLE
[1.x] fix: add index on fof_upload_files.url to prevent unindexed query on every post render

### DIFF
--- a/migrations/2026_03_05_000000_alter_fof_upload_files_add_url_index.php
+++ b/migrations/2026_03_05_000000_alter_fof_upload_files_add_url_index.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) {
+            $table->index('url');
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) {
+            $table->dropIndex(['url']);
+        });
+    },
+];


### PR DESCRIPTION
## Summary

- Adds a database index on the `url` column of `fof_upload_files`
- Every post render containing uploaded images from before v1.6.0 (which lack a `uuid` attribute in their BBcode) triggers a `WHERE url = ?` fallback lookup — without an index this is a full table scan, causing significant MySQL load at scale

## Test plan

- [ ] Run migrations and confirm index is created
- [ ] Verify slow query log no longer shows unindexed `fof_upload_files.url` lookups on post render

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)