### PR TITLE
[2.x] fix: gracefully handle unavailable/unconfigured adapters when rendering posts

### DIFF
--- a/migrations/2026_02_21_000000_migrate_awss3_to_aws_s3.php
+++ b/migrations/2026_02_21_000000_migrate_awss3_to_aws_s3.php
@@ -39,4 +39,7 @@ return [
                 ->update(['value' => json_encode($mimeConfiguration)]);
         }
     },
+    'down' => function (Builder $schema) {
+        // Do nothing..
+    },
 ];

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -85,6 +85,10 @@ class Manager
 
         $instance = $driver ?? $this->{$method}($this->util);
 
+        if ($instance === null) {
+            throw new ValidationException(['upload' => "Cannot instantiate adapter $adapter"]);
+        }
+
         // Stamp the canonical registration key so Util::setMethod() can store it
         // in File::upload_method without deriving it from the class name.
         // This is the only place where the registered key ($adapter) is known.

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -337,7 +337,11 @@ class FileRepository
             ->where('shared', false)
             ->where('created_at', '<', $before)
             ->each(function (File $file) use ($manager, &$count, $confirm) {
-                $adapter = $manager->instantiate($file->upload_method);
+                try {
+                    $adapter = $manager->instantiate($file->upload_method);
+                } catch (ValidationException $e) {
+                    return;
+                }
 
                 if ($confirm !== null && $confirm($file, $adapter) !== true) {
                     return;
@@ -440,7 +444,11 @@ class FileRepository
      */
     public function getUrlForFile(File $file): ?string
     {
-        $adapter = $this->manager->instantiate($file->upload_method);
+        try {
+            $adapter = $this->manager->instantiate($file->upload_method);
+        } catch (ValidationException $e) {
+            return null;
+        }
 
         $supportedAdapters = [
             Adapters\Local::class,
@@ -471,7 +479,11 @@ class FileRepository
             return null;
         }
 
-        $adapter = $this->manager->instantiate($file->upload_method);
+        try {
+            $adapter = $this->manager->instantiate($file->upload_method);
+        } catch (ValidationException $e) {
+            return null;
+        }
 
         $supportedAdapters = [
             Adapters\Local::class,


### PR DESCRIPTION
## Summary

- When a file was uploaded via an adapter that is now removed or unconfigured (e.g. Imgur with no client ID), `Manager::instantiate()` would call the factory method, get `null` back, then crash with a `TypeError` from `property_exists(null, ...)` — breaking the entire forum index/discussion view
- `getUrlForFile()` and `getThumbnailUrlForFile()` now catch `ValidationException` from `instantiate()` and return `null`, so posts degrade gracefully (falling back to the stored URL for imgur files)
- `cleanUp()` skips files whose adapter cannot be instantiated rather than aborting
- Adds the missing `down` key to the `2026_02_21` migration, which caused a `MigrationKeyMissing` error when running `migrate:reset`