### PR TITLE
fix(local): create upload subdirectories as public (0755), not private (0700)

### DIFF
--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -29,6 +29,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use League\Flysystem\Visibility;
 use Overtrue\Flysystem\Qiniu\QiniuAdapter;
 use Qiniu\Http\Client as QiniuClient;
 
@@ -165,7 +167,10 @@ class Manager
     protected function local(Util $util)
     {
         return new Adapters\Local(
-            new LocalFilesystemAdapter($this->paths->public.'/assets/files'),
+            new LocalFilesystemAdapter(
+                $this->paths->public.'/assets/files',
+                PortableVisibilityConverter::fromArray([], Visibility::PUBLIC)
+            ),
             $this->settings,
             $this->url,
             $this->config


### PR DESCRIPTION
## Summary

Fixes #488. Daily upload folders under `public/assets/files` (e.g. `2026-04-30/`) were being created with mode 0700 instead of 0755, so the web server could not serve images out of them even though the image files themselves were written 0644.

## Root cause

The Local adapter is wired up in `src/Adapters/Manager.php`:

```php
new LocalFilesystemAdapter($this->paths->public.'/assets/files')
```

Flysystem v3's `LocalFilesystemAdapter` falls back to `PortableVisibilityConverter::fromArray([])` when no converter is given. That converter defaults `defaultForDirectories` to **PRIVATE**, which maps to **0700**. As a result, every new daily directory created during a write is 0700, hiding the directory from the web server (the user has to `chmod -R 755` after the fact, and the bug returns the next day when a new folder is created).

This matches the v1.x → v2.x regression noted in the issue: v1 used flysystem-1 where directory visibility was effectively 0755, and the upgrade to flysystem-3 silently changed the default.

## Fix

Pass an explicit visibility converter so directories default to **PUBLIC** (0755) while files keep their default 0644:

```php
new LocalFilesystemAdapter(
    $this->paths->public.'/assets/files',
    PortableVisibilityConverter::fromArray([], Visibility::PUBLIC)
)
```

This restores the v1.x behaviour: images live under public dirs that the web server can traverse, while individual files stay 0644.

## Test plan

- [x] `php -l src/Adapters/Manager.php` passes
- [ ] Manual: upload an image on a fresh forum, confirm the new `YYYY-MM-DD` folder is 0755 and the image renders without a chmod

Sister issue (`fof/polls` shares the same root cause): https://github.com/FriendsOfFlarum/polls/issues/123