### PR TITLE
[2.x] fix: display thumbnails at their resized size

### DIFF
--- a/migrations/2026_07_21_000000_alter_fof_upload_files_add_thumbnail_dimensions.php
+++ b/migrations/2026_07_21_000000_alter_fof_upload_files_add_thumbnail_dimensions.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) use ($schema) {
+            if (!$schema->hasColumn('fof_upload_files', 'thumbnail_width')) {
+                $table->unsignedInteger('thumbnail_width')->nullable();
+            }
+            if (!$schema->hasColumn('fof_upload_files', 'thumbnail_height')) {
+                $table->unsignedInteger('thumbnail_height')->nullable();
+            }
+        });
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('fof_upload_files', function (Blueprint $table) {
+            $table->dropColumn(['thumbnail_width', 'thumbnail_height']);
+        });
+    },
+];

--- a/src/Console/BackfillThumbnailsCommand.php
+++ b/src/Console/BackfillThumbnailsCommand.php
@@ -28,7 +28,7 @@ class BackfillThumbnailsCommand extends Command
         {--dry-run : Report how many images would be processed without making any changes}
     ';
 
-    protected $description = 'Backfill missing image thumbnails for existing JPEG, PNG, and GIF uploads';
+    protected $description = 'Backfill missing image thumbnails and thumbnail dimensions for existing JPEG, PNG, and GIF uploads';
 
     public function handle(
         DefaultDownloader $downloader,
@@ -43,15 +43,23 @@ class BackfillThumbnailsCommand extends Command
         $useWebp = (bool) $settings->get('fof-upload.thumbnailWebp', true);
         $maxWidth = max(1, (int) $settings->get('fof-upload.thumbnailMaxWidth', 1000));
 
+        // Process any image that is missing its thumbnail, OR that has a thumbnail but is
+        // missing its recorded thumbnail dimensions (thumbnails backfilled before the
+        // thumbnail_width/thumbnail_height columns existed). Without the dimensions the
+        // rendered <img> falls back to the full-image size and upscales the thumbnail.
         $query = File::query()
             ->whereIn('type', $supportedMimes)
-            ->whereNull('thumbnail_url')
-            ->whereNotIn('upload_method', ['imgur', 'private-shared']);
+            ->whereNotIn('upload_method', ['imgur', 'private-shared'])
+            ->where(function ($q) {
+                $q->whereNull('thumbnail_url')
+                    ->orWhereNull('thumbnail_width')
+                    ->orWhereNull('thumbnail_height');
+            });
 
         $total = $query->count();
 
         if ($total === 0) {
-            $this->info('All eligible images already have thumbnails. Nothing to do.');
+            $this->info('All eligible images already have thumbnails and dimensions. Nothing to do.');
 
             return;
         }
@@ -67,12 +75,15 @@ class BackfillThumbnailsCommand extends Command
         $bar = $this->output->createProgressBar($total);
         $bar->start();
 
-        $updated = 0;
+        $generated = 0;
+        $dimensionsOnly = 0;
         $skipped = 0;
 
-        $query->chunkById($chunkSize, function ($files) use ($downloader, $imageManager, $manager, $bar, $useWebp, $maxWidth, &$updated, &$skipped) {
+        $query->chunkById($chunkSize, function ($files) use ($downloader, $imageManager, $manager, $bar, $useWebp, $maxWidth, &$generated, &$dimensionsOnly, &$skipped) {
             foreach ($files as $file) {
                 try {
+                    $needsThumbnail = empty($file->thumbnail_url);
+
                     $response = $downloader->download($file);
 
                     if ($response->getStatusCode() !== 200) {
@@ -84,6 +95,21 @@ class BackfillThumbnailsCommand extends Command
                     $imageData = $response->getBody()->getContents();
                     $thumb = $imageManager->read($imageData);
                     $thumb->scaleDown(width: $maxWidth);
+
+                    // Record the thumbnail's dimensions regardless of whether we (re)generate
+                    // the file — re-scaling the full image with the same settings yields the
+                    // dimensions of the existing thumbnail too.
+                    $file->thumbnail_width = $thumb->width();
+                    $file->thumbnail_height = $thumb->height();
+
+                    // The thumbnail file already exists; just persist the newly-computed
+                    // dimensions without re-encoding or re-uploading it.
+                    if (!$needsThumbnail) {
+                        $file->save();
+                        $dimensionsOnly++;
+                        $bar->advance();
+                        continue;
+                    }
 
                     $mimeType = $file->type;
 
@@ -111,7 +137,7 @@ class BackfillThumbnailsCommand extends Command
 
                     if ($adapter->storeThumbnail($file, $thumbEncoded->toString(), $ext)) {
                         $file->save();
-                        $updated++;
+                        $generated++;
                     } else {
                         $skipped++;
                     }
@@ -131,6 +157,6 @@ class BackfillThumbnailsCommand extends Command
 
         $bar->finish();
         $this->newLine();
-        $this->info("Done. Updated: $updated, Skipped: $skipped.");
+        $this->info("Done. Thumbnails generated: $generated, Dimensions backfilled: $dimensionsOnly, Skipped: $skipped.");
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -46,6 +46,8 @@ use Illuminate\Support\Str;
  * @property int|null              $image_height
  * @property string|null           $thumbnail_url
  * @property string|null           $thumbnail_path
+ * @property int|null              $thumbnail_width
+ * @property int|null              $thumbnail_height
  */
 class File extends AbstractModel
 {
@@ -57,8 +59,10 @@ class File extends AbstractModel
         'hidden'       => 'boolean',
         'shared'       => 'boolean',
         'created_at'   => \FoF\Upload\Casts\FlexibleDateTime::class,
-        'image_width'  => 'int',
-        'image_height' => 'int',
+        'image_width'      => 'int',
+        'image_height'     => 'int',
+        'thumbnail_width'  => 'int',
+        'thumbnail_height' => 'int',
     ];
 
     protected $fillable = [
@@ -74,6 +78,8 @@ class File extends AbstractModel
         'image_height',
         'thumbnail_url',
         'thumbnail_path',
+        'thumbnail_width',
+        'thumbnail_height',
     ];
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -56,9 +56,9 @@ class File extends AbstractModel
     protected $appends = ['humanSize'];
 
     protected $casts = [
-        'hidden'       => 'boolean',
-        'shared'       => 'boolean',
-        'created_at'   => \FoF\Upload\Casts\FlexibleDateTime::class,
+        'hidden'           => 'boolean',
+        'shared'           => 'boolean',
+        'created_at'       => \FoF\Upload\Casts\FlexibleDateTime::class,
         'image_width'      => 'int',
         'image_height'     => 'int',
         'thumbnail_width'  => 'int',

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -59,16 +59,23 @@ class FormatImagePreview
                     $attributes['alt'] = $file->base_name;
                 }
 
-                if ($file->image_width && $file->image_height) {
-                    $attributes['width'] = $file->image_width;
-                    $attributes['height'] = $file->image_height;
-                }
-
                 // Always set thumbnail_url so the template always has a valid src.
                 // Derived from thumbnail_path + live hostname so CDN domain changes
                 // are reflected automatically, same as getUrlForFile() does for url.
                 // Falls back to the main URL when no thumbnail exists (old posts, Imgur, etc.).
-                $attributes['thumbnail_url'] = $this->files->getThumbnailUrlForFile($file) ?: $attributes['url'];
+                $thumbnailUrl = $this->files->getThumbnailUrlForFile($file);
+                $attributes['thumbnail_url'] = $thumbnailUrl ?: $attributes['url'];
+
+                // The <img> loads thumbnail_url as its src, so width/height must describe
+                // the thumbnail — otherwise the browser upscales it to the full-image size.
+                // Only fall back to the full-image dimensions when no thumbnail is rendered.
+                if ($thumbnailUrl && $file->thumbnail_width && $file->thumbnail_height) {
+                    $attributes['width'] = $file->thumbnail_width;
+                    $attributes['height'] = $file->thumbnail_height;
+                } elseif ($file->image_width && $file->image_height) {
+                    $attributes['width'] = $file->image_width;
+                    $attributes['height'] = $file->image_height;
+                }
             }
 
             return $attributes;

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -77,6 +77,12 @@ class ImageProcessor implements Processable
             $thumb = $this->imageManager->read($upload->getRealPath());
             $thumb->scaleDown(width: $maxWidth);
 
+            // Store the thumbnail's own dimensions so the rendered <img> reserves the
+            // correct layout space for the thumbnail it actually loads, rather than the
+            // (larger) full-image dimensions.
+            $file->thumbnail_width = $thumb->width();
+            $file->thumbnail_height = $thumb->height();
+
             $useWebp = (bool) $this->settings->get('fof-upload.thumbnailWebp', true);
             $thumbEncoded = $useWebp
                 ? $thumb->toWebp(quality: 80)

--- a/tests/unit/Formatter/FormatImagePreviewTest.php
+++ b/tests/unit/Formatter/FormatImagePreviewTest.php
@@ -157,6 +157,45 @@ class FormatImagePreviewTest extends TestCase
     }
 
     #[Test]
+    public function uses_thumbnail_dimensions_when_a_thumbnail_is_rendered(): void
+    {
+        // The <img> src is the thumbnail, so width/height must describe the thumbnail —
+        // not the (larger) full image — otherwise the browser upscales it back to full size.
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file->thumbnail_path = '2026-02-22/1234-photo-thumb.webp';
+        $file->image_width = 1920;
+        $file->image_height = 1080;
+        $file->thumbnail_width = 1000;
+        $file->thumbnail_height = 563;
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringContainsString('width="1000"', $result);
+        $this->assertStringContainsString('height="563"', $result);
+        $this->assertStringNotContainsString('width="1920"', $result);
+        $this->assertStringNotContainsString('height="1080"', $result);
+    }
+
+    #[Test]
+    public function falls_back_to_full_image_dimensions_when_thumbnail_has_no_dimensions(): void
+    {
+        // Legacy thumbnails backfilled before thumbnail_width/height existed: the thumbnail
+        // is rendered but we only know the full-image dimensions. Better than nothing.
+        $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');
+        $file->thumbnail_path = '2026-02-22/1234-photo-thumb.webp';
+        $file->image_width = 1920;
+        $file->image_height = 1080;
+        // thumbnail_width / thumbnail_height are null
+        $formatter = new FormatImagePreview($this->makeRepository($file));
+
+        $result = $this->invoke($formatter, $this->makeXml('abc', 'https://example.com/photo.jpg'));
+
+        $this->assertStringContainsString('width="1920"', $result);
+        $this->assertStringContainsString('height="1080"', $result);
+    }
+
+    #[Test]
     public function does_not_inject_dimensions_when_file_has_none(): void
     {
         $file = $this->makeFile('abc', 'photo.jpg', 'https://example.com/photo.jpg');


### PR DESCRIPTION
## Problem

When "generate thumbnails" is enabled, uploaded images are resized correctly, but they display at the original (full) dimensions instead of the resized size.

The rendered `<img>` loads the resized thumbnail as its `src`, but its `width`/`height` attributes come from `image_width`/`image_height` — the dimensions of the full processed image. The browser upscales the thumbnail back to those dimensions.

## Fix

- Add nullable `thumbnail_width`/`thumbnail_height` columns.
- Capture the thumbnail's dimensions after `scaleDown()` in `ImageProcessor` and store them.
- In `FormatImagePreview`, emit the thumbnail dimensions as the `<img>` `width`/`height` when a thumbnail is rendered; fall back to the full-image dimensions only when no thumbnail exists (old posts, Imgur, legacy thumbnails).

## Existing uploads

`fof:upload:backfill-thumbnails` now also processes files that already have a thumbnail but lack recorded dimensions. For those, it computes and saves the dimensions without re-encoding or re-uploading the existing thumbnail. The summary now reports generated vs. dimensions-only counts.

## Tests

Added cases to `FormatImagePreviewTest` covering thumbnail-dimension precedence and the full-image fallback. Full unit suite passes.