### PR TITLE
[2.x] feat: friendlier maximum file size control

### DIFF
--- a/js/src/admin/components/UploadPage.tsx
+++ b/js/src/admin/components/UploadPage.tsx
@@ -15,6 +15,7 @@ import Link from 'flarum/common/components/Link';
 import type { ExtensionPageAttrs } from 'flarum/admin/components/ExtensionPage';
 import type Mithril from 'mithril';
 import { registerMimePermissions } from '../index';
+import { bestUnitForKb, effectivePhpLimitKb, fromKb, humanizeKb, toKb, UNIT_TO_KB, type SizeUnit } from '../utils/fileSize';
 
 type MimeConfig = {
   adapter: string;
@@ -74,6 +75,9 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
 
   watermarkPositions: Record<string, string> = {};
   composerButtonVisiblityOptions: Record<string, string> = {};
+  // Display-only unit for the "maximum file size" field. The setting itself
+  // (this.values.maxFileSize) is always stored in kilobytes.
+  maxFileSizeUnit!: Stream<SizeUnit>;
   newMimeType!: {
     regex: Stream<string>;
     adapter: Stream<string>;
@@ -160,6 +164,9 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
 
     this.fields.forEach((key) => (this.values[key] = Stream(settings[this.addPrefix(key)])));
     this.checkboxes.forEach((key) => (this.values[key] = Stream(settings[this.addPrefix(key)] === '1')));
+
+    // Choose the friendliest unit that represents the stored KB value exactly.
+    this.maxFileSizeUnit = Stream(bestUnitForKb(Number(this.values.maxFileSize()) || 0));
     this.objects.forEach((key) => {
       const val = settings[this.addPrefix(key)];
       this.values[key] = val ? Stream(JSON.parse(val)) : Stream();
@@ -191,6 +198,13 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
     const maxUpload = app.data.settings[this.addPrefix('php_ini.upload_max_filesize')];
     const fileinfoAvailable = app.data.settings[this.addPrefix('fileinfo_available')] as unknown as boolean | undefined;
 
+    const maxFileSizeKb = Number(this.values.maxFileSize()) || 0;
+    const maxFileSizeUnit = this.maxFileSizeUnit();
+    // Value shown in the number input, expressed in the currently-selected unit.
+    const maxFileSizeInUnit = maxFileSizeKb ? fromKb(maxFileSizeKb, maxFileSizeUnit) : '';
+    const phpLimitKb = effectivePhpLimitKb(maxPost, maxUpload);
+    const exceedsPhpLimit = phpLimitKb != null && maxFileSizeKb > phpLimitKb;
+
     return (
       <div className="UploadPage">
         <div className="UploadPage-container container">
@@ -211,19 +225,47 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
                 <legend>{app.translator.trans('fof-upload.admin.labels.preferences.title')}</legend>
                 <div className="Form-group">
                   <label>{app.translator.trans('fof-upload.admin.labels.preferences.max_file_size')}</label>
-                  <input
-                    className="FormControl"
-                    type="number"
-                    min="0"
-                    value={this.values.maxFileSize() ?? ''}
-                    oninput={withAttr('value', this.values.maxFileSize)}
-                  />
+                  <div className="UploadPage-maxFileSize">
+                    <input
+                      className="FormControl UploadPage-maxFileSize-value"
+                      type="number"
+                      min="0"
+                      step="any"
+                      value={maxFileSizeInUnit}
+                      oninput={withAttr('value', (v: string) => {
+                        const amount = parseFloat(v);
+                        this.values.maxFileSize(Number.isFinite(amount) ? toKb(amount, this.maxFileSizeUnit()) : '');
+                      })}
+                    />
+                    <Select
+                      className="UploadPage-maxFileSize-unit"
+                      options={Object.fromEntries(Object.keys(UNIT_TO_KB).map((u) => [u, u])) as Record<SizeUnit, string>}
+                      value={maxFileSizeUnit}
+                      onchange={(unit: SizeUnit) => this.maxFileSizeUnit(unit)}
+                    />
+                  </div>
                   <p className="helpText">
-                    {app.translator.trans('fof-upload.admin.labels.preferences.php_ini_values', {
-                      post: maxPost,
-                      upload: maxUpload,
+                    {app.translator.trans('fof-upload.admin.labels.preferences.max_file_size_equivalent', {
+                      value: humanizeKb(maxFileSizeKb),
+                      kb: maxFileSizeKb.toLocaleString(),
                     })}
                   </p>
+                  {exceedsPhpLimit ? (
+                    <Alert type="warning" dismissible={false}>
+                      {app.translator.trans('fof-upload.admin.warnings.max_file_size_exceeds_php', {
+                        limit: humanizeKb(phpLimitKb!),
+                        post: maxPost,
+                        upload: maxUpload,
+                      })}
+                    </Alert>
+                  ) : (
+                    <p className="helpText">
+                      {app.translator.trans('fof-upload.admin.labels.preferences.php_ini_values', {
+                        post: maxPost,
+                        upload: maxUpload,
+                      })}
+                    </p>
+                  )}
                 </div>
                 <div className="Form-group">
                   <label>{app.translator.trans('fof-upload.admin.labels.preferences.mime_types')}</label>

--- a/js/src/admin/utils/fileSize.ts
+++ b/js/src/admin/utils/fileSize.ts
@@ -1,0 +1,100 @@
+/**
+ * Helpers for the "maximum file size" admin setting.
+ *
+ * The setting is stored in kilobytes because Laravel's `max:` validation rule
+ * (used by UploadValidator) operates in kilobytes. These helpers let the admin
+ * UI present that value in a friendlier unit and compare it against the PHP
+ * runtime limits.
+ */
+
+export type SizeUnit = 'KB' | 'MB' | 'GB';
+
+/** Multiplier from each unit to kilobytes (1 KB = 1024 bytes, base-2 throughout). */
+export const UNIT_TO_KB: Record<SizeUnit, number> = {
+  KB: 1,
+  MB: 1024,
+  GB: 1024 * 1024,
+};
+
+/**
+ * Pick the largest unit that represents `kb` as a whole number, so the value
+ * round-trips exactly (e.g. 51200 KB → 50 MB, but 51201 KB stays in KB).
+ */
+export function bestUnitForKb(kb: number): SizeUnit {
+  if (kb > 0 && kb % UNIT_TO_KB.GB === 0) return 'GB';
+  if (kb > 0 && kb % UNIT_TO_KB.MB === 0) return 'MB';
+  return 'KB';
+}
+
+/** Convert a value expressed in `unit` to kilobytes. */
+export function toKb(value: number, unit: SizeUnit): number {
+  return Math.round(value * UNIT_TO_KB[unit]);
+}
+
+/** Convert kilobytes to the given unit (not rounded — for display). */
+export function fromKb(kb: number, unit: SizeUnit): number {
+  return kb / UNIT_TO_KB[unit];
+}
+
+/**
+ * Human-readable rendering of a kilobyte value, e.g. 2048000 → "1.95 GB".
+ * Uses at most two decimal places and trims trailing zeros.
+ */
+export function humanizeKb(kb: number): string {
+  if (!Number.isFinite(kb) || kb <= 0) return '0 KB';
+
+  const unit = kb >= UNIT_TO_KB.GB ? 'GB' : kb >= UNIT_TO_KB.MB ? 'MB' : 'KB';
+  const value = fromKb(kb, unit);
+  const rounded = Math.round(value * 100) / 100;
+
+  return `${rounded} ${unit}`;
+}
+
+/**
+ * Parse a PHP shorthand byte value (e.g. "50M", "2G", "512K", "1048576") into
+ * kilobytes. Mirrors PHP's ini size parsing: a trailing K/M/G is base-2, a bare
+ * number is bytes. Returns null when the input can't be parsed.
+ */
+export function phpIniToKb(value: string | undefined | null): number | null {
+  if (value == null) return null;
+
+  const match = String(value)
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s*([KMG])?$/i);
+
+  if (!match) return null;
+
+  const amount = parseFloat(match[1]);
+  const suffix = (match[2] || '').toUpperCase();
+
+  switch (suffix) {
+    case 'G':
+      return amount * UNIT_TO_KB.GB;
+    case 'M':
+      return amount * UNIT_TO_KB.MB;
+    case 'K':
+      return amount;
+    default:
+      // Bare number is bytes; convert to KB.
+      return amount / 1024;
+  }
+}
+
+/**
+ * The effective PHP upload ceiling in kilobytes: the smaller of post_max_size
+ * and upload_max_filesize. A value of "0" for post_max_size means unlimited in
+ * PHP, so it is ignored. Returns null when neither limit can be parsed.
+ */
+export function effectivePhpLimitKb(postMaxSize: string | undefined, uploadMaxFilesize: string | undefined): number | null {
+  const post = phpIniToKb(postMaxSize);
+  const upload = phpIniToKb(uploadMaxFilesize);
+
+  const limits: number[] = [];
+  // post_max_size = 0 means "no limit" in PHP.
+  if (post != null && post > 0) limits.push(post);
+  if (upload != null) limits.push(upload);
+
+  if (limits.length === 0) return null;
+
+  return Math.min(...limits);
+}

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -24,6 +24,26 @@
     margin-bottom: 1rem;
   }
 
+  &-maxFileSize {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    max-width: 320px;
+
+    &-value {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    &-unit {
+      flex: 0 0 auto;
+
+      select {
+        width: auto;
+      }
+    }
+  }
+
   &-mimeTypeRow {
     display: grid;
     grid-template-columns: minmax(160px, 2fr) minmax(120px, 1fr) minmax(180px, 1.5fr) minmax(120px, 1fr) auto;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -87,7 +87,8 @@ fof-upload:
         secret: Secret
         bucket: Bucket
       preferences:
-        max_file_size: Maximum file size (in kilobytes)
+        max_file_size: Maximum file size
+        max_file_size_equivalent: "Stored as <code>{kb}</code> KB ({value})."
         mime_types: "Configure your mime type, upload adapter mapping"
         mime_type_regex_placeholder: "e.g. ^image/(jpeg|png|gif)$"
         mime_type_regex_invalid: "Invalid regex (e.g. empty alternatives like ||)"
@@ -129,6 +130,7 @@ fof-upload:
     warnings:
       fileinfo_missing: |
         The PHP <strong>fileinfo</strong> extension is not loaded on this server. FoF Upload will still work, but MIME type cross-validation is disabled, which reduces protection against spoofed file types. Enable the extension in your PHP configuration for best security.
+      max_file_size_exceeds_php: "This exceeds your server's effective upload limit of <strong>{limit}</strong> (<code>post_max_size={post}</code>, <code>upload_max_filesize={upload}</code>). Uploads larger than that limit will be rejected by PHP regardless of this setting. Lower this value or raise the limits in your <code>php.ini</code> (and <code>client_max_body_size</code> if using Nginx)."
     permissions:
       download_label: Download files
       upload_label: Upload files (base permission, required for all uploads)


### PR DESCRIPTION
## Problem

The "Maximum file size" setting only accepted a raw kilobyte value, so a 2 GB limit had to be entered as `2048000` — hard to read and easy to get wrong. The php.ini note was passive: a value far above the server's real upload limit (e.g. `2048000` KB against `post_max_size=50M`) produced no warning, and those uploads would silently fail at the PHP layer.

## Changes

Frontend-only. The stored value stays in kilobytes, matching the backend validator (`UploadValidator` uses Laravel's `max:` rule in KB), so there is no backend or migration change.

- **Unit selector** — a KB/MB/GB dropdown next to the number input, so you enter `50` + `MB` instead of counting zeros. On load the friendliest unit that represents the stored value exactly is selected.
- **Live equivalent** — help text shows the stored KB value and a human-readable equivalent (e.g. `1.95 GB`).
- **Active warning** — when the configured size exceeds the effective PHP limit (the smaller of `post_max_size` and `upload_max_filesize`), an inline warning replaces the passive note and explains PHP will reject larger uploads regardless. `post_max_size=0` is treated as unlimited.

New helper `js/src/admin/utils/fileSize.ts` handles the conversions and PHP shorthand parsing.

## Notes

Warn-only by design — it does not block saving an over-limit value, so an admin can set it ahead of raising php.ini.

Typecheck passes, production build compiles, prettier clean. `js/dist/` intentionally not committed (build bot regenerates it).