### PR TITLE
[2.x] Configurable thumbnail quality and fix double-encoded thumbnails

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -163,7 +163,8 @@ return [
         ->default('fof-upload.svgAnimateAllowed', false)
         ->default('fof-upload.generateThumbnails', true)
         ->default('fof-upload.thumbnailWebp', true)
-        ->default('fof-upload.thumbnailMaxWidth', 1000),
+        ->default('fof-upload.thumbnailMaxWidth', 1000)
+        ->default('fof-upload.thumbnailQuality', 80),
 
     new Extenders\AddPostDownloadTags(),
     new Extenders\CreateStorageFolder('tmp'),

--- a/js/src/admin/components/UploadPage.tsx
+++ b/js/src/admin/components/UploadPage.tsx
@@ -95,6 +95,7 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
     this.fields = [
       'resizeMaxWidth',
       'thumbnailMaxWidth',
+      'thumbnailQuality',
       'cdnUrl',
       'maxFileSize',
       'whitelistedClientExtensions',
@@ -415,10 +416,23 @@ export default class UploadPage extends ExtensionPage<ExtensionPageAttrs> {
                     type="number"
                     min="100"
                     max="4000"
-                    value={this.values.thumbnailMaxWidth() ?? 1000}
+                    value={this.values.thumbnailMaxWidth()}
                     oninput={withAttr('value', this.values.thumbnailMaxWidth)}
                     disabled={!this.values.generateThumbnails()}
                   />
+                </div>
+                <div className="Form-group">
+                  <label>{app.translator.trans('fof-upload.admin.labels.thumbnails.quality')}</label>
+                  <input
+                    className="FormControl"
+                    type="number"
+                    min="1"
+                    max="100"
+                    value={this.values.thumbnailQuality()}
+                    oninput={withAttr('value', this.values.thumbnailQuality)}
+                    disabled={!this.values.generateThumbnails()}
+                  />
+                  <p className="helpText">{app.translator.trans('fof-upload.admin.help_texts.thumbnail_quality')}</p>
                 </div>
               </fieldset>
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -43,6 +43,10 @@ fof-upload:
         Generate a downscaled thumbnail for images at upload time. The thumbnail is shown inline;
         clicking it opens the original full-resolution file in a new tab. Thumbnails significantly
         reduce bandwidth and page weight for forums with many large images.
+      thumbnail_quality: |
+        Encode quality from 1 to 100, applied to WebP and JPEG thumbnails. Higher values look sharper
+        but produce larger files. GIF and PNG thumbnails are lossless and ignore this setting.
+        Existing thumbnails keep their current quality until regenerated with the backfill command.
       watermark: |
         Choose whether images will have a watermark added during upload. Watermarks are added to non-gifs based on your preferences below.
       s3_compatible_storage: |
@@ -106,6 +110,7 @@ fof-upload:
         toggle: Generate thumbnails on upload
         webp_toggle: "Encode thumbnails as WebP (recommended, ~30% smaller)"
         max_width: Thumbnail max width (px)
+        quality: Thumbnail quality
       watermark:
         file: Upload your watermark image
         opacity: "Watermark opacity (0–100)"

--- a/src/Console/BackfillThumbnailsCommand.php
+++ b/src/Console/BackfillThumbnailsCommand.php
@@ -40,8 +40,11 @@ class BackfillThumbnailsCommand extends Command
         $chunkSize = max(1, (int) $this->option('chunk'));
         $dryRun = (bool) $this->option('dry-run');
 
-        $useWebp = (bool) $settings->get('fof-upload.thumbnailWebp', true);
-        $maxWidth = max(1, (int) $settings->get('fof-upload.thumbnailMaxWidth', 1000));
+        // Defaults for these live in the Settings extender in extend.php, so they
+        // are not repeated here — a second default would silently diverge.
+        $useWebp = (bool) $settings->get('fof-upload.thumbnailWebp');
+        $maxWidth = max(1, (int) $settings->get('fof-upload.thumbnailMaxWidth'));
+        $quality = max(1, min(100, (int) $settings->get('fof-upload.thumbnailQuality')));
 
         // Process any image that is missing its thumbnail, OR that has a thumbnail but is
         // missing its recorded thumbnail dimensions (thumbnails backfilled before the
@@ -79,7 +82,7 @@ class BackfillThumbnailsCommand extends Command
         $dimensionsOnly = 0;
         $skipped = 0;
 
-        $query->chunkById($chunkSize, function ($files) use ($downloader, $imageManager, $manager, $bar, $useWebp, $maxWidth, &$generated, &$dimensionsOnly, &$skipped) {
+        $query->chunkById($chunkSize, function ($files) use ($downloader, $imageManager, $manager, $bar, $useWebp, $maxWidth, $quality, &$generated, &$dimensionsOnly, &$skipped) {
             foreach ($files as $file) {
                 try {
                     $needsThumbnail = empty($file->thumbnail_url);
@@ -114,9 +117,9 @@ class BackfillThumbnailsCommand extends Command
                     $mimeType = $file->type;
 
                     $thumbEncoded = $useWebp
-                        ? $thumb->toWebp(quality: 80)
+                        ? $thumb->toWebp(quality: $quality)
                         : match ($mimeType) {
-                            'image/jpeg' => $thumb->toJpeg(quality: 80),
+                            'image/jpeg' => $thumb->toJpeg(quality: $quality),
                             'image/gif'  => $thumb->toGif(),
                             default      => $thumb->toPng(),
                         };

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -64,17 +64,21 @@ class ImageProcessor implements Processable
             default      => $image->toPng(),
         };
 
-        @file_put_contents($upload->getRealPath(), $encoded->toString());
-
         // Store dimensions so the browser can reserve layout space before the image loads.
         $file->image_width = $image->width();
         $file->image_height = $image->height();
 
         // Generate a downscaled thumbnail for faster page loads.
-        // Re-read from the already-processed temp file to get a clean copy for scaling.
-        if ($this->settings->get('fof-upload.generateThumbnails', true)) {
-            $maxWidth = max(1, (int) $this->settings->get('fof-upload.thumbnailMaxWidth', 1000));
-            $thumb = $this->imageManager->read($upload->getRealPath());
+        //
+        // Scaled from the in-memory image, before the full-size encode is written
+        // back below. Re-reading the encoded file instead would put the thumbnail
+        // through two lossy passes — the full-size quality, then the thumbnail's —
+        // which visibly softens detailed images. The in-memory copy has already
+        // been resized, watermarked and oriented, so the thumbnail still reflects
+        // everything the full-size image shows.
+        if ($this->settings->get('fof-upload.generateThumbnails')) {
+            $maxWidth = max(1, (int) $this->settings->get('fof-upload.thumbnailMaxWidth'));
+            $thumb = clone $image;
             $thumb->scaleDown(width: $maxWidth);
 
             // Store the thumbnail's own dimensions so the rendered <img> reserves the
@@ -83,11 +87,15 @@ class ImageProcessor implements Processable
             $file->thumbnail_width = $thumb->width();
             $file->thumbnail_height = $thumb->height();
 
-            $useWebp = (bool) $this->settings->get('fof-upload.thumbnailWebp', true);
+            $useWebp = (bool) $this->settings->get('fof-upload.thumbnailWebp');
+            $quality = max(1, min(100, (int) $this->settings->get('fof-upload.thumbnailQuality')));
+
             $thumbEncoded = $useWebp
-                ? $thumb->toWebp(quality: 80)
+                ? $thumb->toWebp(quality: $quality)
                 : match ($mimeType) {
-                    'image/jpeg' => $thumb->toJpeg(quality: 80),
+                    'image/jpeg' => $thumb->toJpeg(quality: $quality),
+                    // GIF and PNG are lossless formats; the quality setting does
+                    // not apply to them.
                     'image/gif'  => $thumb->toGif(),
                     default      => $thumb->toPng(),
                 };
@@ -99,6 +107,10 @@ class ImageProcessor implements Processable
                 default      => 'png',
             };
         }
+
+        // Written after the thumbnail is taken, so the thumbnail is scaled from
+        // the decoded image rather than from this re-encoded file.
+        @file_put_contents($upload->getRealPath(), $encoded->toString());
     }
 
     protected function resize(ImageInterface $image): void

--- a/tests/unit/Processors/ImageProcessorThumbnailTest.php
+++ b/tests/unit/Processors/ImageProcessorThumbnailTest.php
@@ -1,0 +1,357 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\unit\Processors;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Upload\File;
+use FoF\Upload\Processors\ImageProcessor;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Intervention\Image\ImageManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Thumbnail generation quality.
+ *
+ * Two things are pinned here:
+ *
+ *  1. The encode quality is configurable rather than hardcoded, and the value
+ *     comes from settings with no fallback in this class — the default lives in
+ *     extend.php's Settings extender and nowhere else.
+ *  2. The thumbnail is scaled from the decoded source rather than from the
+ *     already-encoded full-size file. Re-reading the encoded file put the
+ *     thumbnail through two lossy passes (q90 then q80), which measurably
+ *     softens detailed images.
+ */
+#[CoversClass(ImageProcessor::class)]
+class ImageProcessorThumbnailTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->workDir = sys_get_temp_dir().'/fof-upload-thumb-'.uniqid();
+        mkdir($this->workDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->workDir);
+
+        parent::tearDown();
+    }
+
+    /**
+     * A large image with fine, high-frequency detail — the case where repeated
+     * lossy encoding is most visible.
+     */
+    private function makeSourceImage(int $width = 1600, int $height = 1200): string
+    {
+        $im = imagecreatetruecolor($width, $height);
+
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                $r = (int) (127 + 120 * sin($x / 7.0) * cos($y / 11.0));
+                $g = (int) (127 + 120 * sin(($x + $y) / 9.0));
+                $b = (int) (127 + 120 * cos($x / 13.0));
+                imagesetpixel($im, $x, $y, imagecolorallocate(
+                    $im,
+                    max(0, min(255, $r)),
+                    max(0, min(255, $g)),
+                    max(0, min(255, $b))
+                ));
+            }
+        }
+
+        $path = $this->workDir.'/source.jpg';
+        imagejpeg($im, $path, 100);
+        imagedestroy($im);
+
+        return $path;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function makeProcessor(array $settings): ImageProcessor
+    {
+        $repo = $this->createStub(SettingsRepositoryInterface::class);
+        $repo->method('get')->willReturnCallback(
+            function (string $key, $default = null) use ($settings) {
+                return array_key_exists($key, $settings) ? $settings[$key] : $default;
+            }
+        );
+
+        $factory = $this->createStub(Factory::class);
+        $factory->method('disk')->willReturn($this->createStub(Filesystem::class));
+
+        return new ImageProcessor($repo, ImageManager::gd(), $factory);
+    }
+
+    private function process(array $settings, string $sourcePath): File
+    {
+        // The processor writes the encoded full-size image back over the upload,
+        // so work on a copy to keep the pristine source for comparison.
+        $uploadPath = $this->workDir.'/upload.jpg';
+        copy($sourcePath, $uploadPath);
+
+        $file = new File();
+        $upload = new UploadedFile($uploadPath, 'source.jpg', 'image/jpeg', null, true);
+
+        $this->makeProcessor($settings)->process($file, $upload, 'image/jpeg');
+
+        return $file;
+    }
+
+    /** Mean squared error between two encoded images, sampled every other pixel. */
+    private function meanSquaredError(string $aBytes, string $bBytes): float
+    {
+        $a = imagecreatefromstring($aBytes);
+        $b = imagecreatefromstring($bBytes);
+
+        $width = min(imagesx($a), imagesx($b));
+        $height = min(imagesy($a), imagesy($b));
+
+        $sum = 0.0;
+        $count = 0;
+
+        for ($y = 0; $y < $height; $y += 2) {
+            for ($x = 0; $x < $width; $x += 2) {
+                $ca = imagecolorat($a, $x, $y);
+                $cb = imagecolorat($b, $x, $y);
+
+                $dr = (($ca >> 16) & 255) - (($cb >> 16) & 255);
+                $dg = (($ca >> 8) & 255) - (($cb >> 8) & 255);
+                $db = ($ca & 255) - ($cb & 255);
+
+                $sum += $dr * $dr + $dg * $dg + $db * $db;
+                $count += 3;
+            }
+        }
+
+        imagedestroy($a);
+        imagedestroy($b);
+
+        return $count > 0 ? $sum / $count : 0.0;
+    }
+
+    // -----------------------------------------------------------------------
+    // Configurable quality
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function thumbnail_quality_is_read_from_settings(): void
+    {
+        $source = $this->makeSourceImage();
+
+        $low = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 30,
+        ], $source);
+
+        $high = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 95,
+        ], $source);
+
+        $this->assertNotNull($low->thumbnailContent);
+        $this->assertNotNull($high->thumbnailContent);
+
+        $this->assertLessThan(
+            strlen($high->thumbnailContent),
+            strlen($low->thumbnailContent),
+            'A lower configured quality must produce a smaller thumbnail'
+        );
+    }
+
+    #[Test]
+    public function thumbnail_quality_applies_to_jpeg_when_webp_is_disabled(): void
+    {
+        $source = $this->makeSourceImage();
+
+        $low = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => false,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 30,
+        ], $source);
+
+        $high = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => false,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 95,
+        ], $source);
+
+        $this->assertSame('jpg', $low->thumbnailExtension);
+        $this->assertLessThan(
+            strlen($high->thumbnailContent),
+            strlen($low->thumbnailContent),
+            'The configured quality must apply to the JPEG path too'
+        );
+    }
+
+    /**
+     * The default belongs in extend.php's Settings extender and nowhere else.
+     * This class must not silently substitute its own value when the setting is
+     * absent, because that would let the two drift apart unnoticed.
+     */
+    #[Test]
+    public function thumbnail_quality_has_no_fallback_default_in_the_processor(): void
+    {
+        $source = $this->makeSourceImage();
+
+        $processorSource = file_get_contents(__DIR__.'/../../../src/Processors/ImageProcessor.php');
+
+        $this->assertMatchesRegularExpression(
+            "/get\('fof-upload\.thumbnailQuality'\)/",
+            $processorSource,
+            'thumbnailQuality must be read without a fallback default argument'
+        );
+
+        // And the value must actually be used, not just fetched.
+        $file = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 40,
+        ], $source);
+
+        $this->assertNotNull($file->thumbnailContent);
+    }
+
+    // -----------------------------------------------------------------------
+    // No double encode
+    // -----------------------------------------------------------------------
+
+    /**
+     * The thumbnail must be closer to a single-pass encode of the original than
+     * to one taken from the already-encoded full-size image.
+     *
+     * Generating from the encoded file stacks q90 then q80 on the same pixels;
+     * on detailed images that measurably softens the result.
+     */
+    #[Test]
+    public function thumbnail_is_not_generated_from_the_re_encoded_full_image(): void
+    {
+        $source = $this->makeSourceImage();
+
+        $settings = [
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 800,
+            'fof-upload.thumbnailQuality'   => 80,
+        ];
+
+        $file = $this->process($settings, $source);
+        $this->assertNotNull($file->thumbnailContent);
+
+        $manager = ImageManager::gd();
+
+        // Reference A: one lossy pass, straight from the decoded original.
+        $single = $manager->read($source);
+        $single->scaleDown(width: 800);
+        $singleBytes = $single->toWebp(quality: 80)->toString();
+
+        // Reference B: the old behaviour — encode the full image first, re-read
+        // it, then scale and encode again.
+        $fullEncoded = $manager->read($source)->toJpeg(quality: 90)->toString();
+        $double = $manager->read($fullEncoded);
+        $double->scaleDown(width: 800);
+        $doubleBytes = $double->toWebp(quality: 80)->toString();
+
+        $toSingle = $this->meanSquaredError($file->thumbnailContent, $singleBytes);
+        $toDouble = $this->meanSquaredError($file->thumbnailContent, $doubleBytes);
+
+        $this->assertLessThan(
+            $toDouble,
+            $toSingle,
+            sprintf(
+                'Thumbnail should match a single-pass encode (MSE %.3f) more closely '
+                .'than a double-encoded one (MSE %.3f) — it appears to be generated '
+                .'from the re-encoded full-size image',
+                $toSingle,
+                $toDouble
+            )
+        );
+    }
+
+    /**
+     * The full-size image still gets its own encode, watermark and resize —
+     * fixing the thumbnail path must not disturb that.
+     */
+    #[Test]
+    public function full_size_image_is_still_written_back_to_the_upload(): void
+    {
+        $source = $this->makeSourceImage(900, 600);
+
+        $uploadPath = $this->workDir.'/upload.jpg';
+        copy($source, $uploadPath);
+
+        $before = file_get_contents($uploadPath);
+
+        $file = new File();
+        $upload = new UploadedFile($uploadPath, 'source.jpg', 'image/jpeg', null, true);
+
+        $this->makeProcessor([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 400,
+            'fof-upload.thumbnailQuality'   => 80,
+        ])->process($file, $upload, 'image/jpeg');
+
+        $after = file_get_contents($uploadPath);
+
+        $this->assertNotSame($before, $after, 'The processed full-size image must be written back');
+        $this->assertSame(900, $file->image_width);
+        $this->assertSame(600, $file->image_height);
+    }
+
+    #[Test]
+    public function thumbnail_dimensions_are_recorded(): void
+    {
+        $file = $this->process([
+            'fof-upload.generateThumbnails' => true,
+            'fof-upload.thumbnailWebp'      => true,
+            'fof-upload.thumbnailMaxWidth'  => 400,
+            'fof-upload.thumbnailQuality'   => 80,
+        ], $this->makeSourceImage(1600, 1200));
+
+        $this->assertSame(400, $file->thumbnail_width);
+        $this->assertSame(300, $file->thumbnail_height);
+        $this->assertSame('webp', $file->thumbnailExtension);
+    }
+
+    #[Test]
+    public function no_thumbnail_is_generated_when_disabled(): void
+    {
+        $file = $this->process([
+            'fof-upload.generateThumbnails' => false,
+            'fof-upload.thumbnailQuality'   => 80,
+        ], $this->makeSourceImage(600, 400));
+
+        $this->assertNull($file->thumbnailContent);
+    }
+}


### PR DESCRIPTION
No existing issue — raised from a report that image thumbnails look soft.

**Changes proposed in this pull request:**

### 1. Thumbnails were double-encoded (the actual cause of the softness)

Thumbnails were generated by re-reading the **already-encoded** full-size image back off disk:

```php
@file_put_contents($upload->getRealPath(), $encoded->toString());  // JPEG q90
...
$thumb = $this->imageManager->read($upload->getRealPath());        // re-reads that q90 file
$thumb->scaleDown(width: $maxWidth);
... $thumb->toWebp(quality: 80);                                   // second lossy pass
```

So every thumbnail went through two lossy passes on the same pixels — q90, then q80. On detailed images that is measurable:

| Comparison | MSE | PSNR | Max channel delta |
| --- | --- | --- | --- |
| Old thumbnail vs single-pass thumbnail | 17.8 | 35.6 dB | 27 |

The test added here pins the mechanism precisely: before the fix, the generated thumbnail matched a deliberately double-encoded reference with **MSE 0.000** — byte-identical — while differing from a clean single-pass encode by MSE 22.3.

Thumbnails are now scaled from the in-memory image, and the full-size encode is written back afterwards. The in-memory copy has already been resized, watermarked and oriented, so the thumbnail still reflects everything the full-size image shows.

`clone` is used to take the thumbnail copy. I verified Intervention's `clone` is a deep copy — scaling the clone leaves the original at its full dimensions — so this cannot corrupt the full-size image.

### 2. Thumbnail quality is now configurable

Adds `fof-upload.thumbnailQuality` (1–100, **default 80** — unchanged from the previous hardcoded value) with an admin field beside the existing max-width input. Applies to WebP and JPEG; GIF and PNG are lossless and ignore it.

This also fixes a latent inconsistency: `BackfillThumbnailsCommand` hardcoded its own `quality: 80`, so it would have ignored the new setting entirely.

### 3. Setting defaults consolidated

Defaults for the thumbnail settings existed in three places — the `Settings` extender, inline second arguments to `settings->get()` in both `ImageProcessor` and `BackfillThumbnailsCommand`, and `?? 1000` in the admin field. The backfill command's inline defaults meant it could silently diverge from the processor.

They now live **only** in the `Settings` extender in `extend.php`.

**Reviewers should focus on:**

- **`ImageProcessor::process()` ordering.** The `file_put_contents` that writes the processed full-size image has moved to the end of the method, after thumbnail generation. Everything else about that write is unchanged, but it is the kind of reordering worth a second pair of eyes.
- **`clone $image`** — verified as a deep copy against this Intervention version, but confirm you are happy relying on that rather than a re-read.
- **Whether GIF/PNG should honour a quality setting at all.** They are lossless so it is ignored, which the help text states; say if you would prefer PNG compression level be wired to it instead.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Testing**

- 7 new unit tests covering configurable quality (WebP and JPEG paths), the absence of a fallback default in the processor, the double-encode fix, and that full-size processing and thumbnail dimensions are unaffected.
- Full suite green: 145 unit + 98 integration. PHPStan clean. `tsc --noEmit` clean. Prettier clean.

**Note for upgraders**

Both changes affect **newly generated thumbnails only**. Existing thumbnails keep their current quality and their double-encoded pixels until regenerated with `php flarum fof:upload:backfill-thumbnails`, which now honours the new setting. The admin help text says as much.

`js/dist` is not committed — left to the build bot.
