### PR TITLE
[2.x] Delete files from the adapter they were stored on

### DIFF
--- a/src/Commands/DeleteFileHandler.php
+++ b/src/Commands/DeleteFileHandler.php
@@ -75,7 +75,18 @@ class DeleteFileHandler
 
     protected function deleteFileViaAdaptor(File $file): File|bool
     {
-        $adapter = $this->util->getAdapterForFile($file);
+        // Resolved from where the file was actually stored, not from what its
+        // mime type maps to today — those diverge as soon as an admin edits the
+        // file-type list, and deleting against the wrong adapter silently leaves
+        // the stored object behind.
+        $adapter = $this->util->getStorageAdapterForFile($file);
+
+        if ($adapter === null) {
+            // No adapter could be resolved at all, so there is nothing that can
+            // remove the object. Reported rather than allowed to fatal on a null
+            // call, which previously left both the file and its database row.
+            return false;
+        }
 
         return $adapter->delete($file);
     }

--- a/src/Helpers/Util.php
+++ b/src/Helpers/Util.php
@@ -204,6 +204,41 @@ class Util
         return $this->getAdapterForMime($file->type);
     }
 
+    /**
+     * Resolve the adapter a file is actually stored on.
+     *
+     * Not the same thing as getAdapterForFile(), which maps the file's mime type
+     * through the *current* configuration. That only agrees with reality while
+     * the mapping is unchanged: remap a mime type, or delete the rule that
+     * covered it, and existing files still live wherever they were originally
+     * uploaded. Acting on the wrong adapter leaves the stored object behind —
+     * and for a mime type no longer covered by any rule there is no adapter to
+     * resolve at all.
+     *
+     * File::upload_method records where the file went, which is why cleanUp()
+     * and getUrlForFile() both use it. Falls back to the mime mapping only for
+     * legacy rows written before that column was populated.
+     */
+    public function getStorageAdapterForFile(File $file): ?UploadAdapter
+    {
+        if ($this->isPrivateShared($file)) {
+            throw new ValidationException(['shared-file' => 'Private shared files are handled differently, not by an adapter.']);
+        }
+
+        if ($file->upload_method) {
+            try {
+                return resolve(Manager::class)->instantiate($file->upload_method);
+            } catch (ValidationException $e) {
+                // The adapter it was uploaded with is no longer available — its
+                // package may have been removed. Fall through to the mime
+                // mapping rather than failing outright, so a delete can still
+                // clean up when the two happen to agree.
+            }
+        }
+
+        return $this->getAdapterForMime($file->type);
+    }
+
     public function getAdapterForMime(?string $mime): ?UploadAdapter
     {
         return $this->getAdapter(
@@ -264,7 +299,9 @@ class Util
         $downloadedFile = resolve(Dispatcher::class)->dispatch(new Download($file->uuid, $actor));
 
         $originalFile = clone $file;
-        $adapter = $this->getAdapterForFile($originalFile);
+        // The original is being deleted, so it must be resolved from where it
+        // was stored rather than from the current mime mapping.
+        $adapter = $this->getStorageAdapterForFile($originalFile);
 
         $success = $this->getPrivateDir()->put(
             $file->path,
@@ -272,7 +309,7 @@ class Util
         );
 
         if ($success) {
-            $adapter->delete($originalFile);
+            $adapter?->delete($originalFile);
             $file->upload_method = $this->setMethod();
             $file->url = $this->getFilePrivateUrl($file);
         }

--- a/tests/integration/api/DeleteFileStorageTest.php
+++ b/tests/integration/api/DeleteFileStorageTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Tests\integration\api;
+
+use Flarum\Foundation\Paths;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\User\User;
+use FoF\Upload\File;
+use FoF\Upload\Tests\EnhancedTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Deleting a file must remove the object from storage, not just the database row.
+ *
+ * The delete handler resolves the adapter with Util::getAdapterForFile(), which
+ * maps the file's *mime type* through the current mime configuration. That is
+ * not the same thing as the adapter the file was actually uploaded with —
+ * File::upload_method records that, and is what cleanUp() and getUrlForFile()
+ * both use.
+ *
+ * Whenever the two disagree — the mime mapping was changed after upload, the
+ * file's mime type no longer matches any configured pattern, or the adapter was
+ * uninstalled — the delete is issued against the wrong filesystem. The object is
+ * left behind while the database row disappears, so nothing surfaces the
+ * orphan.
+ */
+class DeleteFileStorageTest extends EnhancedTestCase
+{
+    use RetrievesAuthorizedUsers;
+    use UploadFileTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-upload');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    private function localPath(File $file): string
+    {
+        return $this->app()->getContainer()->make(Paths::class)->public.'/assets/files/'.$file->path;
+    }
+
+    /**
+     * Change a setting after the app has booted.
+     *
+     * TestCase::setting() only seeds the value used when the container is
+     * built, so it has no effect once a request has been made — which is
+     * exactly the scenario these tests need: upload first, reconfigure after.
+     */
+    private function changeSetting(string $key, string $value): void
+    {
+        $this->app()->getContainer()->make(SettingsRepositoryInterface::class)->set($key, $value);
+    }
+
+    private function uploadImage(): File
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/fof/upload', [
+                'authenticatedAs' => 1,
+                'multipart'       => [
+                    $this->uploadFile($this->fixtures('MilkyWay.jpg')),
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $file = File::byUuid($json['data'][0]['attributes']['uuid'])->first();
+
+        $this->assertNotNull($file);
+
+        return $file;
+    }
+
+    #[Test]
+    public function deleting_a_file_removes_it_from_local_storage(): void
+    {
+        $this->addType('^image\\/jpeg$', 'local', 'image-preview');
+
+        $file = $this->uploadImage();
+        $path = $this->localPath($file);
+
+        $this->assertFileExists($path, 'Upload should have written the file to disk');
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/upload/delete/'.$file->uuid, [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(File::byUuid($file->uuid)->first(), 'Database row should be gone');
+        $this->assertFileDoesNotExist($path, 'File should have been removed from storage');
+    }
+
+    /**
+     * The mime configuration is not a reliable way to find a file's adapter: an
+     * admin can change the mapping at any time, and existing files keep pointing
+     * at wherever they were originally stored.
+     */
+    #[Test]
+    public function deleting_a_file_removes_it_from_storage_after_the_mime_mapping_changed(): void
+    {
+        $this->addType('^image\\/jpeg$', 'local', 'image-preview');
+
+        $file = $this->uploadImage();
+        $path = $this->localPath($file);
+
+        $this->assertFileExists($path);
+        $this->assertEquals('local', $file->upload_method);
+
+        // The admin remaps jpegs to a different adapter after the file was
+        // uploaded. The stored object has not moved.
+        //
+        // Written through the live repository rather than $this->setting(),
+        // which only seeds values at app boot and would be ignored here.
+        $this->changeSetting('fof-upload.mimeTypes', json_encode([
+            '^image\\/jpeg$' => [
+                'adapter'  => 'imgur',
+                'template' => 'image-preview',
+            ],
+        ]));
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/upload/delete/'.$file->uuid, [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertFileDoesNotExist(
+            $path,
+            'The file must be deleted from the adapter it was uploaded with, not the one its mime type currently maps to'
+        );
+    }
+
+    /**
+     * A mime type with no matching pattern has no adapter to resolve, so the
+     * delete has nowhere to send the request.
+     */
+    #[Test]
+    public function deleting_a_file_removes_it_from_storage_when_no_mime_rule_matches(): void
+    {
+        $this->addType('^image\\/jpeg$', 'local', 'image-preview');
+
+        $file = $this->uploadImage();
+        $path = $this->localPath($file);
+
+        $this->assertFileExists($path);
+
+        // The rule that covered this file is removed — a plausible outcome of
+        // tidying up the file-type list.
+        $this->changeSetting('fof-upload.mimeTypes', json_encode([
+            '^application\\/pdf$' => [
+                'adapter'  => 'local',
+                'template' => 'file',
+            ],
+        ]));
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/upload/delete/'.$file->uuid, [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertFileDoesNotExist(
+            $path,
+            'The file must still be deleted from storage when its mime type no longer matches a configured rule'
+        );
+    }
+
+    /**
+     * A file whose adapter cannot be resolved at all must fail cleanly.
+     *
+     * Previously this called delete() on null, producing a 500 and leaving both
+     * the stored object and its database row behind — the worst outcome, since
+     * nothing indicated the file still existed.
+     */
+    #[Test]
+    public function deleting_a_file_with_an_unresolvable_adapter_fails_without_a_server_error(): void
+    {
+        $this->addType('^image\\/jpeg$', 'local', 'image-preview');
+
+        $file = $this->uploadImage();
+
+        // Neither the recorded upload method nor the mime mapping can resolve.
+        $file->upload_method = 'no-such-adapter';
+        $file->save();
+
+        $this->changeSetting('fof-upload.mimeTypes', json_encode([
+            '^application\\/pdf$' => [
+                'adapter'  => 'local',
+                'template' => 'file',
+            ],
+        ]));
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/upload/delete/'.$file->uuid, [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertNotEquals(500, $response->getStatusCode(), 'Must not fatal when no adapter can be resolved');
+
+        // The row is deliberately kept: the object is still in storage, so
+        // dropping the record would orphan it with nothing left pointing at it.
+        $this->assertNotNull(File::byUuid($file->uuid)->first(), 'The record must survive a failed storage delete');
+    }
+}


### PR DESCRIPTION
Deleting a file left the stored object behind on S3 and local storage.

**Changes proposed in this pull request:**

`DeleteFileHandler` resolved the storage adapter by mapping the file's mime type through the *current* configuration, instead of `File::upload_method` which records where the file was actually uploaded. The two agree only until an admin edits the file-type list.

Once they diverge:

- **Mime remapped after upload** → the delete goes to the wrong filesystem, fails, and returns 422. The object stays.
- **No rule matches the mime type** → the adapter resolves to `null`, `delete()` fatals with a 500, and *both* the object and its database row are left.

Now resolved from `upload_method`, matching what `cleanUp()` and `getUrlForFile()` already do, with a fallback to the mime mapping for legacy rows and a null check.

`moveFileToPrivate()` had the same bug when deleting the original after a move. `moveFileToPublic()` is deliberately unchanged — it *uploads* to wherever the configuration now points, so current config is correct there.

**Reviewers should focus on:**

- The fallback in `Util::getStorageAdapterForFile()`. When `upload_method` names an adapter whose package is no longer installed it falls through to the mime mapping rather than failing outright, on the grounds that a delete should still work when the two happen to agree.
- Whether keeping the database row on a failed storage delete is the right call. It is the existing behaviour and I have preserved it: dropping the record would orphan the object with nothing left pointing at it.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Testing**

4 new integration tests covering local deletion, a remapped mime type, an unmatched mime type, and an unresolvable adapter. Verified they are meaningful by reverting the fix — two fail, and pass again once reapplied.

Full suite green: 145 unit + 102 integration. PHPStan clean.

**Note**

This prevents new orphans; it does not clean up existing ones. `fof:upload:clean-up` handles files with no post attachment, but objects whose database row has already been removed are untracked and need clearing from the bucket manually.
